### PR TITLE
Centralize package metadata in Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>4.1.3</VersionPrefix>
+        <VersionPrefix>4.2.0</VersionPrefix>
         <!-- SPDX license identifier for Apache 2.0 -->
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 
@@ -18,6 +18,17 @@
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
     </PropertyGroup>
+
+    <PropertyGroup>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageIcon>icon.png</PackageIcon>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="..\..\icon.png" Pack="true" PackagePath="" Visible="False" />
+        <None Include="..\..\README.md" Pack="true" PackagePath="" Visible="False" />
+    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">

--- a/src/AlexaVoxCraft.MediatR.Lambda/AlexaVoxCraft.MediatR.Lambda.csproj
+++ b/src/AlexaVoxCraft.MediatR.Lambda/AlexaVoxCraft.MediatR.Lambda.csproj
@@ -10,14 +10,7 @@
         <Title>AlexaVoxCraft.MediatR.Lambda</Title>
         <Description>Lambda hosting and middleware integration for Alexa skills using MediatR and AlexaVoxCraft.</Description>
         <PackageTags>alexa;lambda;aws;mediatR;voxcraft;hosting;middleware</PackageTags>
-        <PackageIcon>icon.png</PackageIcon>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
-        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     </PropertyGroup>
-    <ItemGroup>
-        <None Include="..\..\icon.png" Pack="true" PackagePath="" Visible="False" />
-        <None Include="..\..\README.md" Pack="true" PackagePath="" Visible="False" />
-    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.14.0" />

--- a/src/AlexaVoxCraft.MediatR/AlexaVoxCraft.MediatR.csproj
+++ b/src/AlexaVoxCraft.MediatR/AlexaVoxCraft.MediatR.csproj
@@ -10,14 +10,9 @@
         <Title>AlexaVoxCraft.MediatR</Title>
         <Description>MediatR support for Alexa skill development, enabling clean request routing and handler composition.</Description>
         <PackageTags>alexa;mediatR;skills;request-handling;voice;voxcraft</PackageTags>
-        <PackageIcon>icon.png</PackageIcon>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
-        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="..\..\icon.png" Pack="true" PackagePath="" Visible="False" />
-        <None Include="..\..\README.md" Pack="true" PackagePath="" Visible="False" />
         <None Include="..\AlexaVoxCraft.MediatR.Generators\bin\$(Configuration)\netstandard2.0\AlexaVoxCraft.MediatR.Generators.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
         <None Include="AlexaVoxCraft.MediatR.props" Pack="true" PackagePath="build" Visible="true" />
         <None Include="AlexaVoxCraft.MediatR.targets" Pack="true" PackagePath="build" Visible="true" />

--- a/src/AlexaVoxCraft.Model.Apl/AlexaVoxCraft.Model.Apl.csproj
+++ b/src/AlexaVoxCraft.Model.Apl/AlexaVoxCraft.Model.Apl.csproj
@@ -11,14 +11,7 @@
     <Title>AlexaVoxCraft.Model.Apl</Title>
     <Description>Strongly-typed Alexa Presentation Language (APL) model support for rendering rich UI in multimodal Alexa skills.</Description>
     <PackageTags>alexa;apl;presentation;model;visuals;multimodal;voxcraft</PackageTags>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
   </PropertyGroup>
-  <ItemGroup>
-    <None Include="..\..\icon.png" Pack="true" PackagePath="" Visible="False" />
-    <None Include="..\..\README.md" Pack="true" PackagePath="" Visible="False" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\AlexaVoxCraft.Model\AlexaVoxCraft.Model.csproj" />

--- a/src/AlexaVoxCraft.Model/AlexaVoxCraft.Model.csproj
+++ b/src/AlexaVoxCraft.Model/AlexaVoxCraft.Model.csproj
@@ -10,14 +10,7 @@
         <Title>AlexaVoxCraft.Model</Title>
         <Description>Base model definitions for Alexa skill requests, responses, session state, and directives.</Description>
         <PackageTags>alexa;model;request;response;directive;voxcraft;skills</PackageTags>
-        <PackageIcon>icon.png</PackageIcon>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
-        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     </PropertyGroup>
-    <ItemGroup>
-        <None Include="..\..\icon.png" Pack="true" PackagePath="" Visible="False" />
-        <None Include="..\..\README.md" Pack="true" PackagePath="" Visible="False" />
-    </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1'">
         <PackageReference Include="System.Text.Json" Version="8.0.6" />
     </ItemGroup>

--- a/src/AlexaVoxCraft.Observability/AlexaVoxCraft.Observability.csproj
+++ b/src/AlexaVoxCraft.Observability/AlexaVoxCraft.Observability.csproj
@@ -10,14 +10,7 @@
         <Title>AlexaVoxCraft.Observability</Title>
         <Description>OpenTelemetry instrumentation for AlexaVoxCraft, providing comprehensive observability for Alexa skill development.</Description>
         <PackageTags>alexa;opentelemetry;observability;telemetry;metrics;tracing;voxcraft</PackageTags>
-        <PackageIcon>icon.png</PackageIcon>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
-        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     </PropertyGroup>
-    <ItemGroup>
-        <None Include="..\..\icon.png" Pack="true" PackagePath="" Visible="False" />
-        <None Include="..\..\README.md" Pack="true" PackagePath="" Visible="False" />
-    </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\AlexaVoxCraft.MediatR\AlexaVoxCraft.MediatR.csproj"/>

--- a/src/AlexaVoxCraft.Smapi/AlexaVoxCraft.Smapi.csproj
+++ b/src/AlexaVoxCraft.Smapi/AlexaVoxCraft.Smapi.csproj
@@ -5,6 +5,11 @@
         <Nullable>enable</Nullable>
         <TargetFrameworks>net10.0;net8.0;net9.0</TargetFrameworks>
         <LangVersion>default</LangVersion>
+
+        <PackageId>AlexaVoxCraft.Smapi</PackageId>
+        <Title>AlexaVoxCraft.Smapi</Title>
+        <Description>SMAPI (Skill Management API) client for programmatic Alexa skill management in CI/CD pipelines and external tooling.</Description>
+        <PackageTags>alexa;smapi;skill-management;api;ci-cd;voxcraft;automation</PackageTags>
     </PropertyGroup>
     <ItemGroup Condition="'$(TargetFramework)'=='net8.0'">
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />


### PR DESCRIPTION
## Summary

- Move `PackageReadmeFile`, `PackageIcon`, and `PackageLicenseExpression` to `Directory.Build.props`
- Move `icon.png` and `README.md` file inclusions to `Directory.Build.props`
- Remove duplicated package metadata from individual csproj files
- Add `Description` and `PackageTags` to `AlexaVoxCraft.Smapi.csproj`

## Test plan

- [x] Build succeeds with no errors
- [ ] Verify NuGet packages include icon, readme, and license after packing

🤖 Generated with [Claude Code](https://claude.com/claude-code)