### PR TITLE
Add default voice support for ResponseBuilder

### DIFF
--- a/AlexaVoxCraft.TestKit/SpecimenBuilders/OptionsSpecimenBuilder.cs
+++ b/AlexaVoxCraft.TestKit/SpecimenBuilders/OptionsSpecimenBuilder.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using AlexaVoxCraft.MediatR.DI;
+using AlexaVoxCraft.Model.Response.Ssml;
 using AlexaVoxCraft.TestKit.RequestSpecifications;
 using AutoFixture.Kernel;
 using Microsoft.Extensions.Options;
@@ -31,6 +32,7 @@ public class OptionsSpecimenBuilder(IRequestSpecification requestSpecification) 
             _ when parameterName.Contains("validconfiguration") => CreateValidOptions(),
             _ when parameterName.Contains("emptyconfiguration") => CreateEmptyOptions(),
             _ when parameterName.Contains("whitespaceconfiguration") => CreateWhitespaceOptions(),
+            _ when parameterName.Contains("voicedconfiguration") || parameterName.Contains("withvoice") => CreateOptionsWithDefaultVoice(),
             _ => CreateDefaultOptions()
         };
     }
@@ -88,6 +90,17 @@ public class OptionsSpecimenBuilder(IRequestSpecification requestSpecification) 
         {
             SkillId = "amzn1.ask.skill.default-test-id",
             CustomUserAgent = "TestAgent/1.0"
+        };
+        return Options.Create(config);
+    }
+
+    private static IOptions<SkillServiceConfiguration> CreateOptionsWithDefaultVoice()
+    {
+        var config = new SkillServiceConfiguration
+        {
+            SkillId = "amzn1.ask.skill.default-test-id",
+            CustomUserAgent = "TestAgent/1.0",
+            DefaultVoiceName = PollyVoices.Generative.Matthew
         };
         return Options.Create(config);
     }

--- a/AlexaVoxCraft.TestKit/SpecimenBuilders/SkillServiceConfigurationSpecimenBuilder.cs
+++ b/AlexaVoxCraft.TestKit/SpecimenBuilders/SkillServiceConfigurationSpecimenBuilder.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using AlexaVoxCraft.MediatR.DI;
+using AlexaVoxCraft.Model.Response.Ssml;
 using AlexaVoxCraft.TestKit.RequestSpecifications;
 using AutoFixture.Kernel;
 
@@ -29,6 +30,7 @@ public class SkillServiceConfigurationSpecimenBuilder(IRequestSpecification requ
             _ when parameterName.Contains("empty") => CreateEmptySkillIdConfiguration(),
             _ when parameterName.Contains("null") => CreateNullSkillIdConfiguration(),
             _ when parameterName.Contains("whitespace") => CreateWhitespaceSkillIdConfiguration(),
+            _ when parameterName.Contains("voiced") || parameterName.Contains("withvoice") => CreateConfigurationWithDefaultVoice(),
             _ => CreateDefaultConfiguration()
         };
     }
@@ -84,6 +86,16 @@ public class SkillServiceConfigurationSpecimenBuilder(IRequestSpecification requ
         {
             SkillId = "amzn1.ask.skill.default-test-id",
             CustomUserAgent = "TestAgent/1.0"
+        };
+    }
+
+    private static SkillServiceConfiguration CreateConfigurationWithDefaultVoice()
+    {
+        return new SkillServiceConfiguration
+        {
+            SkillId = "amzn1.ask.skill.default-test-id",
+            CustomUserAgent = "TestAgent/1.0",
+            DefaultVoiceName = PollyVoices.Generative.Matthew
         };
     }
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>4.2.0</VersionPrefix>
+        <VersionPrefix>4.3.0</VersionPrefix>
         <!-- SPDX license identifier for Apache 2.0 -->
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 

--- a/src/AlexaVoxCraft.MediatR.Generators/AlexaVoxCraft.MediatR.Generators.csproj
+++ b/src/AlexaVoxCraft.MediatR.Generators/AlexaVoxCraft.MediatR.Generators.csproj
@@ -15,7 +15,7 @@
     <ItemGroup>
         <!-- Keep Roslyn deps private so they don't leak to consumers -->
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
     </ItemGroup>
 
     <!-- Optional: write generated files locally while debugging this project itself -->

--- a/src/AlexaVoxCraft.MediatR.Lambda/AlexaVoxCraft.MediatR.Lambda.csproj
+++ b/src/AlexaVoxCraft.MediatR.Lambda/AlexaVoxCraft.MediatR.Lambda.csproj
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.14.0" />
+        <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.14.1" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4"/>
         <PackageReference Include="LayeredCraft.Logging.CompactJsonFormatter" Version="1.0.1.3" />
         <PackageReference Include="Serilog.AspNetCore" Version="9.0.0"/>

--- a/src/AlexaVoxCraft.MediatR/AlexaVoxCraft.MediatR.csproj
+++ b/src/AlexaVoxCraft.MediatR/AlexaVoxCraft.MediatR.csproj
@@ -29,7 +29,7 @@
 
     <ItemGroup>
         <PackageReference Include="LayeredCraft.StructuredLogging" Version="1.1.3.11" />
-        <PackageReference Include="OpenTelemetry.Api" Version="1.13.1" />
+        <PackageReference Include="OpenTelemetry.Api" Version="1.14.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AlexaVoxCraft.MediatR/DI/SkillServiceConfiguration.cs
+++ b/src/AlexaVoxCraft.MediatR/DI/SkillServiceConfiguration.cs
@@ -27,8 +27,19 @@ public class SkillServiceConfiguration
     
     /// <summary>
     /// Gets or sets the default voice name to use for speech synthesis in responses.
+    /// When set, all speech output from <see cref="Response.IResponseBuilder.Speak(string?)"/>
+    /// and <see cref="Response.IResponseBuilder.Reprompt(string?)"/> will be wrapped in an
+    /// SSML <c>&lt;voice&gt;</c> element using this voice.
     /// If not set, the Alexa service will use the default voice for the locale.
     /// </summary>
+    /// <remarks>
+    /// Use <see cref="Model.Response.Ssml.PollyVoices"/> for available Amazon Polly voice name constants.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// config.DefaultVoiceName = PollyVoices.Generative.Matthew;
+    /// </code>
+    /// </example>
     public string? DefaultVoiceName { get; set; }
 
     /// <summary>

--- a/src/AlexaVoxCraft.MediatR/DI/SkillServiceConfiguration.cs
+++ b/src/AlexaVoxCraft.MediatR/DI/SkillServiceConfiguration.cs
@@ -24,6 +24,12 @@ public class SkillServiceConfiguration
     /// This should match the skill ID configured in the Alexa Developer Console.
     /// </summary>
     public string? SkillId { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the default voice name to use for speech synthesis in responses.
+    /// If not set, the Alexa service will use the default voice for the locale.
+    /// </summary>
+    public string? DefaultVoiceName { get; set; }
 
     /// <summary>
     /// Gets or sets the service lifetime for registered handlers and services.

--- a/src/AlexaVoxCraft.MediatR/Response/ResponseExtensions.cs
+++ b/src/AlexaVoxCraft.MediatR/Response/ResponseExtensions.cs
@@ -1,0 +1,73 @@
+using AlexaVoxCraft.Model.Response.Ssml;
+
+namespace AlexaVoxCraft.MediatR.Response;
+
+/// <summary>
+/// Provides extension methods for building Alexa skill responses with SSML voice support.
+/// </summary>
+/// <remarks>
+/// These extensions allow wrapping text, SSML nodes, or collections of SSML elements
+/// in an Amazon Polly voice. Use <see cref="PollyVoices"/> for available voice name constants.
+/// </remarks>
+public static class ResponseExtensions
+{
+    extension(string text)
+    {
+        /// <summary>
+        /// Wraps the text in an SSML <c>&lt;voice&gt;</c> element using the specified Amazon Polly voice.
+        /// </summary>
+        /// <param name="voiceName">The Amazon Polly voice name to use. See <see cref="PollyVoices"/> for available voices.</param>
+        /// <returns>An <see cref="ISsml"/> element containing the text wrapped in a voice element.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="text"/> or <paramref name="voiceName"/> is null or whitespace.</exception>
+        public ISsml WithVoice(string voiceName)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(text);
+            ArgumentException.ThrowIfNullOrWhiteSpace(voiceName);
+
+            return new PlainText(text).WithVoice(voiceName);
+        }
+    }
+
+    extension(ISsml node)
+    {
+        /// <summary>
+        /// Wraps the SSML element in an SSML <c>&lt;voice&gt;</c> element using the specified Amazon Polly voice.
+        /// </summary>
+        /// <param name="voiceName">The Amazon Polly voice name to use. See <see cref="PollyVoices"/> for available voices.</param>
+        /// <returns>An <see cref="ISsml"/> element containing the node wrapped in a voice element.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="node"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="voiceName"/> is null or whitespace.</exception>
+        public ISsml WithVoice(string voiceName)
+        {
+            ArgumentNullException.ThrowIfNull(node);
+            ArgumentException.ThrowIfNullOrWhiteSpace(voiceName);
+
+            return new Voice(voiceName)
+            {
+                Elements = [node]
+            };
+        }
+    }
+
+    extension(IEnumerable<ISsml> nodes)
+    {
+        /// <summary>
+        /// Wraps the collection of SSML elements in an SSML <c>&lt;voice&gt;</c> element using the specified Amazon Polly voice.
+        /// </summary>
+        /// <param name="voiceName">The Amazon Polly voice name to use. See <see cref="PollyVoices"/> for available voices.</param>
+        /// <returns>An <see cref="ISsml"/> element containing all nodes wrapped in a single voice element.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="nodes"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="voiceName"/> is null or whitespace.</exception>
+        public ISsml WithVoice(string voiceName)
+        {
+            ArgumentNullException.ThrowIfNull(nodes);
+            ArgumentException.ThrowIfNullOrWhiteSpace(voiceName);
+
+            return new Voice(voiceName)
+            {
+                Elements = nodes.ToList()
+            };
+        }
+    }
+
+}

--- a/src/AlexaVoxCraft.Model/Response/Ssml/PollyVoices.cs
+++ b/src/AlexaVoxCraft.Model/Response/Ssml/PollyVoices.cs
@@ -1,0 +1,189 @@
+namespace AlexaVoxCraft.Model.Response.Ssml;
+
+/// <summary>
+/// Provides constants for Amazon Polly voice IDs that currently have
+/// <c>Generative</c> and/or <c>Long-form</c> variants, as documented in
+/// the Amazon Polly Developer Guide.
+/// <para>
+/// These values are intended to be used anywhere a Polly voice ID is required,
+/// such as:
+/// <list type="bullet">
+///   <item>
+///     <description>The <c>name</c> attribute on the SSML <c>&lt;voice&gt;</c> element.</description>
+///   </item>
+///   <item>
+///     <description>The <c>VoiceId</c> parameter to Polly APIs (for example, <c>SynthesizeSpeech</c>).</description>
+///   </item>
+/// </list>
+/// </para>
+/// <para>
+/// This list is a snapshot based on the AWS documentation at the time of writing,
+/// and is not guaranteed to remain exhaustive as new voices are added.
+/// See the official Amazon Polly documentation for the most up-to-date list.
+/// </para>
+/// </summary>
+/// <remarks>
+/// Voice IDs are provided in their ASCII form (for example, <c>Celine</c> instead of <c>Céline</c>,
+/// <c>Andres</c> instead of <c>Andrés</c>) to match the IDs returned by the Polly
+/// <c>DescribeVoices</c> API and the "Name/ID" column in the "Available voices" table.
+/// </remarks>
+public static class PollyVoices
+{
+    /// <summary>
+    /// Contains voice IDs that have a Generative engine variant in Amazon Polly.
+    /// <para>
+    /// All of these voices are also available as conversational NTTS voices.
+    /// </para>
+    /// </summary>
+    public static class Generative
+    {
+        // English
+
+        /// <summary>English (Australian), female.</summary>
+        public const string Olivia = "Olivia";           // en-AU
+
+        /// <summary>English (Indian), female.</summary>
+        public const string Kajal = "Kajal";             // en-IN
+
+        /// <summary>English (Ireland), female.</summary>
+        public const string Niamh = "Niamh";             // en-IE
+
+        /// <summary>English (South African), female.</summary>
+        public const string Ayanda = "Ayanda";           // en-ZA
+
+        /// <summary>English (UK), female.</summary>
+        public const string Amy = "Amy";                 // en-GB
+
+        /// <summary>English (US), female.</summary>
+        public const string Danielle = "Danielle";       // en-US
+
+        /// <summary>English (US), female.</summary>
+        public const string Joanna = "Joanna";           // en-US
+
+        /// <summary>English (US), male.</summary>
+        public const string Matthew = "Matthew";         // en-US
+
+        /// <summary>English (US), female.</summary>
+        public const string Ruth = "Ruth";               // en-US
+
+        /// <summary>English (US), female.</summary>
+        public const string Salli = "Salli";             // en-US
+
+        /// <summary>English (US), male.</summary>
+        public const string Stephen = "Stephen";         // en-US
+
+        // Dutch
+
+        /// <summary>Dutch (Belgian), female.</summary>
+        public const string Lisa = "Lisa";               // nl-BE
+
+        /// <summary>Dutch (Netherlands), female.</summary>
+        public const string Laura = "Laura";             // nl-NL
+
+        // French
+
+        /// <summary>French (Belgian), female.</summary>
+        public const string Isabelle = "Isabelle";       // fr-BE
+
+        /// <summary>French (Canadian), female.</summary>
+        public const string Gabrielle = "Gabrielle";     // fr-CA
+
+        /// <summary>French (Canadian), male.</summary>
+        public const string Liam = "Liam";               // fr-CA
+
+        /// <summary>French (France), female (Céline/Celine).</summary>
+        public const string Celine = "Celine";           // fr-FR
+
+        /// <summary>French (France), female.</summary>
+        public const string Lea = "Lea";                 // fr-FR
+
+        /// <summary>French (France), male.</summary>
+        public const string Remi = "Remi";               // fr-FR
+
+        // German
+
+        /// <summary>German (Austria), female.</summary>
+        public const string Hannah = "Hannah";           // de-AT
+
+        /// <summary>German (Germany), male.</summary>
+        public const string Daniel = "Daniel";           // de-DE
+
+        /// <summary>German (Germany), female.</summary>
+        public const string Vicki = "Vicki";             // de-DE
+
+        // Italian
+
+        /// <summary>Italian (Italy), female.</summary>
+        public const string Bianca = "Bianca";           // it-IT
+
+        // Korean
+
+        /// <summary>Korean (Korea), female.</summary>
+        public const string Seoyeon = "Seoyeon";         // ko-KR
+
+        // Polish
+
+        /// <summary>Polish (Poland), female.</summary>
+        public const string Ewa = "Ewa";                 // pl-PL
+
+        /// <summary>Polish (Poland), female.</summary>
+        public const string Ola = "Ola";                 // pl-PL
+
+        // Portuguese
+
+        /// <summary>Portuguese (Brazilian), female.</summary>
+        public const string Camila = "Camila";           // pt-BR
+
+        // Spanish
+
+        /// <summary>Spanish (Mexican), male (Andrés/Andres).</summary>
+        public const string Andres = "Andres";           // es-MX
+
+        /// <summary>Spanish (Mexican), female (Mía/Mia).</summary>
+        public const string Mia = "Mia";                 // es-MX
+
+        /// <summary>Spanish (Spain), female.</summary>
+        public const string Lucia = "Lucia";             // es-ES
+
+        /// <summary>Spanish (Spain), male.</summary>
+        public const string Sergio = "Sergio";           // es-ES
+
+        /// <summary>Spanish (US), female.</summary>
+        public const string Lupe = "Lupe";               // es-US
+
+        /// <summary>Spanish (US), male.</summary>
+        public const string Pedro = "Pedro";             // es-US
+    }
+
+    /// <summary>
+    /// Contains voice IDs that have a Long-form engine variant in Amazon Polly.
+    /// <para>
+    /// Long-form voices are optimized for longer content such as articles, training
+    /// material, or marketing videos, and are also based on generative TTS technology.
+    /// </para>
+    /// </summary>
+    public static class LongForm
+    {
+        // English (US)
+
+        /// <summary>English (US), female long-form voice.</summary>
+        public const string Danielle = "Danielle";       // en-US
+
+        /// <summary>English (US), male long-form voice.</summary>
+        public const string Gregory = "Gregory";         // en-US
+
+        /// <summary>English (US), female long-form voice.</summary>
+        public const string Ruth = "Ruth";               // en-US
+
+        /// <summary>English (US), male long-form voice.</summary>
+        public const string Patrick = "Patrick";         // en-US
+
+        // Spanish (Spain)
+
+        /// <summary>Spanish (Spain), female long-form voice.</summary>
+        public const string Alba = "Alba";               // es-ES
+
+        /// <summary>Spanish (Spain), male long-form voice (Raúl/Raul).</summary>
+        public const string Raul = "Raul";               // es-ES
+    }
+}

--- a/src/AlexaVoxCraft.Observability/AlexaVoxCraft.Observability.csproj
+++ b/src/AlexaVoxCraft.Observability/AlexaVoxCraft.Observability.csproj
@@ -17,7 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="OpenTelemetry" Version="1.13.1" />
+        <PackageReference Include="OpenTelemetry" Version="1.14.0" />
     </ItemGroup>
 
 </Project>

--- a/test/AlexaVoxCraft.MediatR.Generator.Tests/AlexaVoxCraft.MediatR.Generator.Tests.csproj
+++ b/test/AlexaVoxCraft.MediatR.Generator.Tests/AlexaVoxCraft.MediatR.Generator.Tests.csproj
@@ -24,9 +24,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
         <PackageReference Include="Verify.SourceGenerators" Version="2.5.0" />
-        <PackageReference Include="Verify.XunitV3" Version="31.5.3" />
+        <PackageReference Include="Verify.XunitV3" Version="31.7.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/AlexaVoxCraft.MediatR.Lambda.Tests/AlexaVoxCraft.MediatR.Lambda.Tests.csproj
+++ b/test/AlexaVoxCraft.MediatR.Lambda.Tests/AlexaVoxCraft.MediatR.Lambda.Tests.csproj
@@ -17,7 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.13.1" />
+        <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.14.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/AlexaVoxCraft.MediatR.Tests/AlexaVoxCraft.MediatR.Tests.csproj
+++ b/test/AlexaVoxCraft.MediatR.Tests/AlexaVoxCraft.MediatR.Tests.csproj
@@ -17,7 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.13.1" />
+        <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.14.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/AlexaVoxCraft.Model.Apl.Tests/AlexaVoxCraft.Model.Apl.Tests.csproj
+++ b/test/AlexaVoxCraft.Model.Apl.Tests/AlexaVoxCraft.Model.Apl.Tests.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Verify.XunitV3" Version="31.0.5"/>
+        <PackageReference Include="Verify.XunitV3" Version="31.7.2" />
     </ItemGroup>
     <ItemGroup>
         <!-- Embed all JSON fixtures under Examples/ -->

--- a/test/AlexaVoxCraft.Model.Tests/AlexaVoxCraft.Model.Tests.csproj
+++ b/test/AlexaVoxCraft.Model.Tests/AlexaVoxCraft.Model.Tests.csproj
@@ -22,7 +22,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Verify.XunitV3" Version="31.0.5"/>
+        <PackageReference Include="Verify.XunitV3" Version="31.7.2" />
     </ItemGroup>
     <ItemGroup>
         <!-- Embed all JSON fixtures under Examples/ -->

--- a/test/AlexaVoxCraft.Smapi.Tests/AlexaVoxCraft.Smapi.Tests.csproj
+++ b/test/AlexaVoxCraft.Smapi.Tests/AlexaVoxCraft.Smapi.Tests.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Verify.XunitV3" Version="31.0.5"/>
+        <PackageReference Include="Verify.XunitV3" Version="31.7.2" />
     </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Add `DefaultVoiceName` property to `SkillServiceConfiguration` for configuring a default Amazon Polly voice
- Add `PollyVoices` static class with constants for Generative and Long-form Polly voice IDs
- Add `ResponseExtensions` with `WithVoice()` extension methods for wrapping SSML in voice elements
- Update `DefaultResponseBuilder` to automatically wrap `Speak()` and `Reprompt()` output in voice elements when configured
- Add comprehensive XML documentation to all new and modified classes
- Add 7 new unit tests for the default voice feature
- Update TestKit specimen builders to support voiced configuration testing

## Usage

Configure the default voice in your skill configuration:

```csharp
services.Configure<SkillServiceConfiguration>(config =>
{
    config.DefaultVoiceName = PollyVoices.Generative.Matthew;
});
```

All `Speak()` and `Reprompt()` calls will automatically be wrapped with the configured voice:

```xml
<speak><voice name="Matthew">Hello world</voice></speak>
```

## Test plan

- [x] All 143 MediatR tests pass
- [x] New tests verify voice wrapping for Speak, Reprompt, and SpeakAudio
- [x] Tests verify no voice wrapping when DefaultVoiceName is not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)