### PR TITLE
Release version 5.0.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>5.0.0-beta</VersionPrefix>
+        <VersionPrefix>5.0.0</VersionPrefix>
         <!-- SPDX license identifier for Apache 2.0 -->
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ public class LaunchRequestHandler : IRequestHandler<LaunchRequest>
 
 ## 📖 Documentation
 
-📚 **[Complete Documentation](https://layeredcraft.github.io/alexa-vox-craft/)** - Comprehensive guides and examples
+📚 **[Complete Documentation](https://alexavoxcraft.layeredcraft.dev/)** - Comprehensive guides and examples
 
 ### Core Components
 


### PR DESCRIPTION
## Summary
- Release stable version 5.0.0 by removing beta designation
- Update documentation URL to new domain (alexavoxcraft.layeredcraft.dev)

## Changes
- **Directory.Build.props**: Changed `VersionPrefix` from `5.0.0-beta` to `5.0.0`
- **README.md**: Updated documentation link to https://alexavoxcraft.layeredcraft.dev/

## Release Notes
This marks the stable release of AlexaVoxCraft 5.0.0 with:
- OpenTelemetry observability support
- Simplified Lambda handler registration API
- Enhanced AWS Lambda integration
- Comprehensive telemetry and metrics

## Test Plan
- [x] Verify version string is correct in Directory.Build.props
- [x] Confirm documentation URL is accessible
- [ ] CI/CD pipeline will automatically build and publish to NuGet.org
- [ ] GitHub Actions will create release tag `v5.0.0.{run_number}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)