### PR TITLE
Bump dependency patch versions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>5.0.0</VersionPrefix>
+        <VersionPrefix>5.0.1</VersionPrefix>
         <!-- SPDX license identifier for Apache 2.0 -->
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 

--- a/src/AlexaVoxCraft.Lambda.Host/AlexaVoxCraft.Lambda.Host.csproj
+++ b/src/AlexaVoxCraft.Lambda.Host/AlexaVoxCraft.Lambda.Host.csproj
@@ -18,7 +18,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="AwsLambda.Host" Version="1.2.1" />
+      <PackageReference Include="AwsLambda.Host" Version="1.3.0" />
     </ItemGroup>
 
 </Project>

--- a/src/AlexaVoxCraft.Lambda/AlexaVoxCraft.Lambda.csproj
+++ b/src/AlexaVoxCraft.Lambda/AlexaVoxCraft.Lambda.csproj
@@ -14,7 +14,7 @@
 
     <ItemGroup>
       <PackageReference Include="Amazon.Lambda.Core" Version="2.8.0" />
-      <PackageReference Include="LayeredCraft.StructuredLogging" Version="1.1.3.11" />
+      <PackageReference Include="LayeredCraft.StructuredLogging" Version="1.1.5.15" />
       <PackageReference Include="Serilog" Version="4.3.0" />
     </ItemGroup>
 

--- a/src/AlexaVoxCraft.MediatR.Lambda/AlexaVoxCraft.MediatR.Lambda.csproj
+++ b/src/AlexaVoxCraft.MediatR.Lambda/AlexaVoxCraft.MediatR.Lambda.csproj
@@ -31,7 +31,7 @@
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.11" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
     </ItemGroup>
 
 </Project>

--- a/src/AlexaVoxCraft.MediatR/AlexaVoxCraft.MediatR.csproj
+++ b/src/AlexaVoxCraft.MediatR/AlexaVoxCraft.MediatR.csproj
@@ -28,7 +28,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="LayeredCraft.StructuredLogging" Version="1.1.3.11" />
+        <PackageReference Include="LayeredCraft.StructuredLogging" Version="1.1.5.15" />
         <PackageReference Include="OpenTelemetry.Api" Version="1.14.0" />
     </ItemGroup>
 
@@ -50,9 +50,9 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)'=='net10.0'">
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.1" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.1" />
     </ItemGroup>
 
 </Project>

--- a/src/AlexaVoxCraft.Model/AlexaVoxCraft.Model.csproj
+++ b/src/AlexaVoxCraft.Model/AlexaVoxCraft.Model.csproj
@@ -18,7 +18,7 @@
         <PackageReference Include="System.Text.Json" Version="9.0.11" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="System.Text.Json" Version="10.0.0" />
+        <PackageReference Include="System.Text.Json" Version="10.0.1" />
     </ItemGroup>
 
 </Project>

--- a/src/AlexaVoxCraft.Smapi/AlexaVoxCraft.Smapi.csproj
+++ b/src/AlexaVoxCraft.Smapi/AlexaVoxCraft.Smapi.csproj
@@ -26,14 +26,14 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)'=='net10.0'">
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.1" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.1" />
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="LayeredCraft.StructuredLogging" Version="1.1.3.11" />
+      <PackageReference Include="LayeredCraft.StructuredLogging" Version="1.1.5.15" />
     </ItemGroup>
 
 </Project>

--- a/test/AlexaVoxCraft.MediatR.Generator.Tests/AlexaVoxCraft.MediatR.Generator.Tests.csproj
+++ b/test/AlexaVoxCraft.MediatR.Generator.Tests/AlexaVoxCraft.MediatR.Generator.Tests.csproj
@@ -26,7 +26,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
         <PackageReference Include="Verify.SourceGenerators" Version="2.5.0" />
-        <PackageReference Include="Verify.XunitV3" Version="31.7.3" />
+        <PackageReference Include="Verify.XunitV3" Version="31.8.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/AlexaVoxCraft.Model.Apl.Tests/AlexaVoxCraft.Model.Apl.Tests.csproj
+++ b/test/AlexaVoxCraft.Model.Apl.Tests/AlexaVoxCraft.Model.Apl.Tests.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Verify.XunitV3" Version="31.7.3" />
+        <PackageReference Include="Verify.XunitV3" Version="31.8.0" />
     </ItemGroup>
     <ItemGroup>
         <!-- Embed all JSON fixtures under Examples/ -->

--- a/test/AlexaVoxCraft.Model.Tests/AlexaVoxCraft.Model.Tests.csproj
+++ b/test/AlexaVoxCraft.Model.Tests/AlexaVoxCraft.Model.Tests.csproj
@@ -22,7 +22,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Verify.XunitV3" Version="31.7.3" />
+        <PackageReference Include="Verify.XunitV3" Version="31.8.0" />
     </ItemGroup>
     <ItemGroup>
         <!-- Embed all JSON fixtures under Examples/ -->

--- a/test/AlexaVoxCraft.Smapi.Tests/AlexaVoxCraft.Smapi.Tests.csproj
+++ b/test/AlexaVoxCraft.Smapi.Tests/AlexaVoxCraft.Smapi.Tests.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Verify.XunitV3" Version="31.7.3" />
+        <PackageReference Include="Verify.XunitV3" Version="31.8.0" />
     </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary\n- bump solution version to 5.0.1\n- update LayeredCraft.StructuredLogging, Microsoft.Extensions.*, System.Text.Json, AwsLambda.Host to latest patches\n- refresh Verify.XunitV3 for test projects\n\n## Testing\n- dotnet test (fails: MSBuild cannot bind named pipe due to permission restrictions in sandbox)