### PR TITLE
feat(core): implement IList<T> for APLValueCollection with materialize pattern

### DIFF
--- a/AlexaVoxCraft.slnx
+++ b/AlexaVoxCraft.slnx
@@ -22,6 +22,7 @@
     <File Path="docs/components/request-handling.md" />
     <File Path="docs/components/session-management.md" />
     <File Path="docs/components/source-generation.md" />
+    <File Path="docs\components\observability.md" />
   </Folder>
   <Folder Name="/docs/examples/">
     <File Path="docs/examples/index.md" />

--- a/docs/components/apl-integration.md
+++ b/docs/components/apl-integration.md
@@ -4,6 +4,29 @@ AlexaVoxCraft provides comprehensive support for Alexa Presentation Language (AP
 
 > 🎯 **Trivia Skill Examples**: All code examples demonstrate building **visual trivia questions** with multiple-choice answers, score displays, and interactive touch/voice responses.
 
+## ⚠️ Breaking Changes in Version 6.0.0
+
+Version 6.0.0 introduces significant improvements to the APL collection type system. If you're upgrading from v5.x:
+
+**Key Changes:**
+- `APLValue<IList<T>>` and `APLValue<List<T>>` have been replaced with `APLValueCollection<T>`
+- `APLValueCollection<T>` now implements `IList<T>` directly for natural collection operations
+- The `Items` property is now read-only (`IReadOnlyList<T>`)
+- Collection mutations (Add, Remove, Clear, etc.) are now performed directly on the collection object
+
+**Quick Migration Example:**
+```csharp
+// ❌ Before (v5.x)
+container.Items!.Add(new Text { Content = "Hello" });
+var count = container.Items?.Count ?? 0;
+
+// ✅ After (v6.0.0+)
+container.Add(new Text { Content = "Hello" });
+var count = container.Count;
+```
+
+> 📖 For complete migration details and additional examples, see the [Version 6.0.0 Breaking Changes](https://github.com/LayeredCraft/alexa-vox-craft#-version-600-breaking-changes) section in the README.
+
 ## :rocket: Features
 
 - **:art: Fluent Document Builder**: Intuitive API for creating complex APL documents

--- a/src/AlexaVoxCraft.Model.Apl/APLValueCollection_T.cs
+++ b/src/AlexaVoxCraft.Model.Apl/APLValueCollection_T.cs
@@ -7,38 +7,124 @@ using AlexaVoxCraft.Model.Apl.JsonConverter;
 
 namespace AlexaVoxCraft.Model.Apl;
 
+/// <summary>
+/// Represents an APL value that serializes as either:
+/// - a JSON array (when item-backed), or
+/// - a raw expression string (when expression-backed).
+/// Mutations materialize the collection by clearing any existing expression.
+/// </summary>
 [CollectionBuilder(typeof(APLValueCollectionBuilder), nameof(APLValueCollectionBuilder.Create))]
 [JsonConverter(typeof(APLValueCollectionConverterFactory))]
-public class APLValueCollection<T> : APLValue, IEnumerable<T>
+public sealed class APLValueCollection<T> : APLValue, IList<T>, IReadOnlyList<T>
 {
-    private List<T> _items;
+    private readonly List<T> _items;
 
+    /// <summary>
+    /// Initializes an empty, item-backed collection.
+    /// </summary>
     public APLValueCollection()
     {
         _items = [];
     }
 
+    /// <summary>
+    /// Initializes an item-backed collection.
+    /// </summary>
     public APLValueCollection(ReadOnlySpan<T> items)
     {
         _items = [..items];
     }
 
+    /// <summary>
+    /// Initializes an item-backed collection.
+    /// </summary>
     public APLValueCollection(IEnumerable<T> items)
     {
         _items = [..items];
     }
 
-    public IList<T>? Items
-    {
-        get => _items;
-        set => _items = value is null ? [] : [..value];
-    }
+    /// <summary>
+    /// A read-only view of the current items (helpful for debugging/inspection).
+    /// Prefer list APIs directly on this type (Count/Add/Remove/etc.).
+    /// </summary>
+    public IReadOnlyList<T> Items => _items;
 
+    /// <inheritdoc />
     public override object GetValue() => _items;
 
+    /// <inheritdoc />
+    public int Count => _items.Count;
+
+    /// <inheritdoc />
+    public bool IsReadOnly => false;
+
+    /// <inheritdoc />
+    public T this[int index]
+    {
+        get => _items[index];
+        set
+        {
+            Materialize();
+            _items[index] = value;
+        }
+    }
+
+    /// <inheritdoc />
+    public void Add(T item)
+    {
+        Materialize();
+        _items.Add(item);
+    }
+
+    /// <inheritdoc />
+    public void Clear()
+    {
+        Materialize();
+        _items.Clear();
+    }
+
+    /// <inheritdoc />
+    public bool Contains(T item) => _items.Contains(item);
+
+    /// <inheritdoc />
+    public void CopyTo(T[] array, int arrayIndex) => _items.CopyTo(array, arrayIndex);
+
+    /// <inheritdoc />
+    public int IndexOf(T item) => _items.IndexOf(item);
+
+    /// <inheritdoc />
+    public void Insert(int index, T item)
+    {
+        Materialize();
+        _items.Insert(index, item);
+    }
+
+    /// <inheritdoc />
+    public bool Remove(T item)
+    {
+        Materialize();
+        return _items.Remove(item);
+    }
+
+    /// <inheritdoc />
+    public void RemoveAt(int index)
+    {
+        Materialize();
+        _items.RemoveAt(index);
+    }
+
+    /// <inheritdoc />
     public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private void Materialize()
+    {
+        if (!string.IsNullOrEmpty(Expression))
+        {
+            Expression = null;
+        }
+    }
 
     // Can't have implicit conversion from IEnumerable<T> (interface)
     // Use concrete types instead

--- a/src/AlexaVoxCraft.Model.Apl/JsonConverter/APLValueCollectionConverter.cs
+++ b/src/AlexaVoxCraft.Model.Apl/JsonConverter/APLValueCollectionConverter.cs
@@ -44,7 +44,7 @@ public class APLValueCollectionConverter<T> : JsonConverter<APLValueCollection<T
         // Handle single item using virtual method
         if (reader.TokenType == SingleTokenType)
         {
-            ReadSingle(ref reader, options, collection.Items!);
+            ReadSingle(ref reader, options, collection);
             return collection;
         }
 
@@ -56,7 +56,7 @@ public class APLValueCollectionConverter<T> : JsonConverter<APLValueCollection<T
                 var item = JsonSerializer.Deserialize<T>(ref reader, options);
                 if (item is not null)
                 {
-                    collection.Items!.Add(item);
+                    collection.Add(item);
                 }
             }
             return collection;
@@ -74,23 +74,22 @@ public class APLValueCollectionConverter<T> : JsonConverter<APLValueCollection<T
             return;
         }
 
-        var items = value.Items;
-        if (items is null || items.Count == 0)
+        if (value.Count == 0)
         {
             writer.WriteNullValue();
             return;
         }
 
         // Write single item using virtual method if AlwaysOutputArray is false
-        if (!_alwaysOutputArray && items.Count == 1)
+        if (!_alwaysOutputArray && value.Count == 1)
         {
-            JsonSerializer.Serialize(writer, OutputArrayItem(items[0]), options);
+            JsonSerializer.Serialize(writer, OutputArrayItem(value[0]), options);
             return;
         }
 
         // Write array using virtual method for each item
         writer.WriteStartArray();
-        foreach (var item in items)
+        foreach (var item in value)
         {
             JsonSerializer.Serialize(writer, OutputArrayItem(item), options);
         }

--- a/test/AlexaVoxCraft.Model.Apl.Legacy.Tests/ExtensionTests.cs
+++ b/test/AlexaVoxCraft.Model.Apl.Legacy.Tests/ExtensionTests.cs
@@ -20,7 +20,7 @@ public class ExtensionTests
     {
         var backstack = new BackstackExtension("Back");
         var doc = new APLDocument(APLDocumentVersion.V1_4);
-        doc.Extensions!.Items!.Add(backstack);
+        doc.Extensions!.Add(backstack);
         doc.Settings = new APLDocumentSettings();
         doc.Settings.Add(backstack.Name, new BackStackSettings { BackstackId = "myDocument" });
         Assert.True(Utility.CompareJson(doc, "ExtensionBackStack.json", _output));
@@ -74,7 +74,7 @@ public class ExtensionTests
     {
         var smartMotion = new SmartMotionExtension("SmartMotion");
         var doc = new APLDocument(APLDocumentVersion.V1_4);
-        doc.Extensions!.Items!.Add(smartMotion);
+        doc.Extensions!.Add(smartMotion);
         doc.Settings = new APLDocumentSettings();
         doc.Settings.Add(smartMotion.Name, new SmartMotionSettings
         {
@@ -174,7 +174,7 @@ public class ExtensionTests
     {
         var entitySensing = new EntitySensingExtension("EntitySensing");
         var doc = new APLDocument(APLDocumentVersion.V1_4);
-        doc.Extensions!.Items!.Add(entitySensing);
+        doc.Extensions!.Add(entitySensing);
         doc.Settings = new APLDocumentSettings();
         doc.Settings.Add(entitySensing.Name, new EntitySensingSettings
         {
@@ -207,7 +207,7 @@ public class ExtensionTests
     {
         var dataStore = new DataStoreExtension("DataStore");
         var doc = new APLDocument(APLDocumentVersion.V2023_1);
-        doc.Extensions!.Items!.Add(dataStore);
+        doc.Extensions!.Add(dataStore);
         doc.Settings = new APLDocumentSettings();
         doc.Settings.Add(dataStore.Name, new DataStoreSettings
         {


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary

This PR implements a major redesign of the APL collection type system by making `APLValueCollection<T>` implement `IList<T>` directly, eliminating the need for `.Items` property access for mutations. This provides natural collection ergonomics while maintaining full backward compatibility for read-only operations.

**Breaking Change**: This is a **Version 6.0.0** breaking change that affects how users interact with APL collections.

---

## 🎯 Key Changes

### Core Implementation (`APLValueCollection_T.cs`)
- ✅ Implements `IList<T>` and `IReadOnlyList<T>` interfaces
- ✅ Made class `sealed` for better performance
- ✅ Made `_items` field `readonly`
- ✅ Transformed `Items` property from `IList<T>?` to `IReadOnlyList<T>` (getter-only)
- ✅ Implemented all 11 IList<T> members: Count, IsReadOnly, indexer, Add, Clear, Contains, CopyTo, Remove, IndexOf, Insert, RemoveAt

### Materialize Pattern
- ✅ Added `Materialize()` method that clears `Expression` when collection is mutated
- ✅ Mutating operations (Add, Remove, Clear, Insert, RemoveAt, indexer set) call Materialize()
- ✅ Read-only operations (Count, Contains, IndexOf, GetEnumerator) preserve Expression

### Converter Updates (`APLValueCollectionConverter.cs`)
- ✅ Removed `.Items!` null-suppression operators
- ✅ Updated to use direct collection access

### Test Coverage
- ✅ **All existing tests passing**: 66/66 in Model.Apl.Tests, 149/149 in Legacy tests
- ✅ **11 new tests** for IList<T> interface behavior
- ✅ **10 new tests** for Materialize() pattern behavior
- ✅ Updated existing tests to use direct collection API

### Documentation
- ✅ Added comprehensive Version 6.0.0 breaking changes section to README.md
- ✅ Added migration guide with before/after examples
- ✅ Updated docs/components/apl-integration.md with breaking changes summary

---

## 🔄 API Before & After

### Before (v5.x) - Awkward .Items Access
```csharp
collection.Items!.Add(new Text());
var count = collection.Items?.Count ?? 0;
var first = collection.Items![0];
collection.Items!.Clear();
```

### After (v6.0+) - Natural Collection Operations
```csharp
collection.Add(new Text());
var count = collection.Count;
var first = collection[0];
collection.Clear();
```

---

## 💡 Materialize Pattern

When you mutate a collection that has an `Expression` set, the expression is automatically cleared:

```csharp
APLValueCollection<APLComponent> collection = "${data.items}";
collection.Expression; // "${data.items}"

collection.Add(new Text());  // Mutation materializes the collection
collection.Expression; // null - expression cleared

// Read-only operations preserve expression
var count = collection.Count;  // Does NOT clear Expression
```

---

## ✅ Checklist

- [x] My changes build cleanly (0 errors, 0 warnings)
- [x] I've added/updated relevant tests (21 new tests, all passing)
- [x] I've added/updated documentation (README.md and docs/components/apl-integration.md)
- [x] I've followed the coding style for this project
- [x] I've tested the changes locally (all 215 tests passing)

---

## 🧪 Test Results

```
AlexaVoxCraft.Model.Apl.Tests: 66/66 tests passed ✅
AlexaVoxCraft.Model.Apl.Legacy.Tests: 149/149 tests passed ✅ (8 skipped for CI)
Total: 215 tests passing
```

---

## 📚 Migration Impact

**High Impact:**
- Custom APL component implementations
- Code directly manipulating APL collections  
- Any code using `APLValue<IList<T>>` or `APLValue<List<T>>`

**Low Impact:**
- Most skill code using the document builder API
- Code that only reads from collections
- Expression-based data binding (still works)

---

## 💬 Notes for Reviewers

### Design Decisions

1. **Why sealed class?** Better performance and clearer intent - this is a leaf node in the type hierarchy.

2. **Why readonly field?** Ensures `_items` cannot be reassigned, only modified through the public API.

3. **Why IReadOnlyList<T> for Items property?** Signals that mutations should go through IList<T> methods, while still allowing inspection/debugging.

4. **Why Materialize pattern?** Prevents confusion between expression-backed and item-backed collections. Once you mutate, you're committed to items.

### What Still Works

- ✅ The `Items` property exists for backward compatibility (read-only)
- ✅ Collection expressions: `[item1, item2, item3]`
- ✅ LINQ operations: `collection.OfType<Text>().ToList()`
- ✅ Implicit conversions from `List<T>`, `T[]`, and `string`
- ✅ Expression-based data binding: `"${data.items}"`
- ✅ JSON serialization (unchanged behavior)

### Benefits

1. **Natural API**: Direct collection operations without `.Items` indirection
2. **Type Safety**: Cannot accidentally use `APLValue<List<T>>` anymore  
3. **Better IntelliSense**: Collection methods appear directly on the type
4. **Clearer Intent**: Materialize pattern makes expression/items relationship explicit
5. **Standard .NET Patterns**: Implements `IList<T>` like other collection types

---

🤖 Generated with [Claude Code](https://claude.ai/code)