### PR TITLE
chore(deps): upgrade to MinimalLambda 2.2.0 stable and release version 6.0.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>6.0.1-beta</VersionPrefix>
+        <VersionPrefix>6.0.1</VersionPrefix>
         <!-- SPDX license identifier for Apache 2.0 -->
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 

--- a/src/AlexaVoxCraft.MinimalLambda/AlexaVoxCraft.MinimalLambda.csproj
+++ b/src/AlexaVoxCraft.MinimalLambda/AlexaVoxCraft.MinimalLambda.csproj
@@ -18,7 +18,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="MinimalLambda" Version="2.2.0-beta.1" />
+      <PackageReference Include="MinimalLambda" Version="2.2.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Upgrades to the stable release of MinimalLambda 2.2.0 and removes the beta suffix for AlexaVoxCraft version 6.0.1.

### Changes
- **MinimalLambda**: `2.2.0-beta.1` → `2.2.0` (stable release)
- **VersionPrefix**: `6.0.1-beta` → `6.0.1` (stable release)

### Context

MinimalLambda 2.2.0 has been released as stable after successful beta testing. This upgrade ensures AlexaVoxCraft.MinimalLambda uses the production-ready version of the dependency.

### Files Changed
- `Directory.Build.props` - Version prefix updated to 6.0.1
- `src/AlexaVoxCraft.MinimalLambda/AlexaVoxCraft.MinimalLambda.csproj` - MinimalLambda package reference updated to 2.2.0

### Testing
- ✅ All existing tests continue to pass
- ✅ No breaking changes in MinimalLambda 2.2.0
- ✅ Backward compatible upgrade

🤖 Generated with [Claude Code](https://claude.ai/code)