### PR TITLE
feat(core): add slot sample utterances support to SlotBuilder

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>7.0.0-beta</VersionPrefix>
+        <VersionPrefix>7.0.1-beta</VersionPrefix>
         <!-- SPDX license identifier for Apache 2.0 -->
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 

--- a/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/SlotBuilder.cs
+++ b/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/SlotBuilder.cs
@@ -9,6 +9,7 @@ public sealed class SlotBuilder
 {
     private readonly string _name;
     private readonly string _type;
+    private readonly List<string> _samples = [];
     private bool _isRequired;
 
     /// <summary>
@@ -46,6 +47,35 @@ public sealed class SlotBuilder
     }
 
     /// <summary>
+    /// Adds a sample utterance to the slot.
+    /// </summary>
+    /// <param name="sample">The sample utterance.</param>
+    /// <returns>The current <see cref="SlotBuilder"/>.</returns>
+    public SlotBuilder WithSample(string sample)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sample);
+        _samples.Add(sample);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds multiple sample utterances to the slot.
+    /// </summary>
+    /// <param name="samples">The sample utterances.</param>
+    /// <returns>The current <see cref="SlotBuilder"/>.</returns>
+    public SlotBuilder WithSamples(params string[] samples)
+    {
+        ArgumentNullException.ThrowIfNull(samples);
+
+        foreach (var sample in samples)
+        {
+            WithSample(sample);
+        }
+
+        return this;
+    }
+
+    /// <summary>
     /// Builds the slot instance.
     /// </summary>
     /// <returns>The constructed <see cref="IntentSlot"/>.</returns>
@@ -54,6 +84,7 @@ public sealed class SlotBuilder
         {
             Name = _name,
             Type = _type,
-            IsRequired = _isRequired
+            IsRequired = _isRequired,
+            Samples = _samples.Count > 0 ? [.. _samples] : null
         };
 }

--- a/src/AlexaVoxCraft.Smapi/Models/InteractionModel/IntentSlot.cs
+++ b/src/AlexaVoxCraft.Smapi/Models/InteractionModel/IntentSlot.cs
@@ -25,4 +25,11 @@ public sealed record IntentSlot
     [JsonPropertyName("elicitationRequired")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool IsRequired { get; init; }
+
+    /// <summary>
+    /// Gets the sample utterances for this slot.
+    /// </summary>
+    [JsonPropertyName("samples")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<string>? Samples { get; init; }
 }

--- a/test/AlexaVoxCraft.Smapi.Tests/Builders/InteractionModel/SlotBuilderTests.cs
+++ b/test/AlexaVoxCraft.Smapi.Tests/Builders/InteractionModel/SlotBuilderTests.cs
@@ -1,0 +1,62 @@
+using AlexaVoxCraft.Smapi.Builders.InteractionModel;
+
+namespace AlexaVoxCraft.Smapi.Tests.Builders.InteractionModel;
+
+public sealed class SlotBuilderTests
+{
+    [Fact]
+    public async Task Build_WithNoSamples_OmitsSamplesFromResult()
+    {
+        var slot = new SlotBuilder("productCategory", "factType")
+            .Build();
+
+        await Verify(slot);
+    }
+
+    [Fact]
+    public async Task Build_WithSingleSample_IncludesSampleInResult()
+    {
+        var slot = new SlotBuilder("productCategory", "factType")
+            .WithSample("{productCategory} pack")
+            .Build();
+
+        await Verify(slot);
+    }
+
+    [Fact]
+    public async Task Build_WithMultipleSamplesViaWithSample_IncludesAllSamples()
+    {
+        var slot = new SlotBuilder("productCategory", "factType")
+            .WithSample("{productCategory} pack")
+            .WithSample("Tell me about a {productCategory} pack")
+            .WithSample("Tell me about the {productCategory} pack")
+            .Build();
+
+        await Verify(slot);
+    }
+
+    [Fact]
+    public async Task Build_WithMultipleSamplesViaWithSamples_IncludesAllSamples()
+    {
+        var slot = new SlotBuilder("productCategory", "factType")
+            .WithSamples(
+                "{productCategory} pack",
+                "Tell me about a {productCategory} pack",
+                "Tell me about the {productCategory} pack",
+                "Tell me about {productCategory} pack")
+            .Build();
+
+        await Verify(slot);
+    }
+
+    [Fact]
+    public async Task Build_WithSamplesAndRequired_CombinesPropertiesCorrectly()
+    {
+        var slot = new SlotBuilder("productCategory", "factType")
+            .Required()
+            .WithSamples("{productCategory} pack", "Tell me about a {productCategory} pack")
+            .Build();
+
+        await Verify(slot);
+    }
+}

--- a/test/AlexaVoxCraft.Smapi.Tests/Snapshots/SlotBuilderTests.Build_WithMultipleSamplesViaWithSample_IncludesAllSamples.verified.json
+++ b/test/AlexaVoxCraft.Smapi.Tests/Snapshots/SlotBuilderTests.Build_WithMultipleSamplesViaWithSample_IncludesAllSamples.verified.json
@@ -1,0 +1,10 @@
+﻿{
+  "Name": "productCategory",
+  "Type": "factType",
+  "IsRequired": false,
+  "Samples": [
+    "{productCategory} pack",
+    "Tell me about a {productCategory} pack",
+    "Tell me about the {productCategory} pack"
+  ]
+}

--- a/test/AlexaVoxCraft.Smapi.Tests/Snapshots/SlotBuilderTests.Build_WithMultipleSamplesViaWithSamples_IncludesAllSamples.verified.json
+++ b/test/AlexaVoxCraft.Smapi.Tests/Snapshots/SlotBuilderTests.Build_WithMultipleSamplesViaWithSamples_IncludesAllSamples.verified.json
@@ -1,0 +1,11 @@
+﻿{
+  "Name": "productCategory",
+  "Type": "factType",
+  "IsRequired": false,
+  "Samples": [
+    "{productCategory} pack",
+    "Tell me about a {productCategory} pack",
+    "Tell me about the {productCategory} pack",
+    "Tell me about {productCategory} pack"
+  ]
+}

--- a/test/AlexaVoxCraft.Smapi.Tests/Snapshots/SlotBuilderTests.Build_WithNoSamples_OmitsSamplesFromResult.verified.json
+++ b/test/AlexaVoxCraft.Smapi.Tests/Snapshots/SlotBuilderTests.Build_WithNoSamples_OmitsSamplesFromResult.verified.json
@@ -1,0 +1,5 @@
+﻿{
+  "Name": "productCategory",
+  "Type": "factType",
+  "IsRequired": false
+}

--- a/test/AlexaVoxCraft.Smapi.Tests/Snapshots/SlotBuilderTests.Build_WithSamplesAndRequired_CombinesPropertiesCorrectly.verified.json
+++ b/test/AlexaVoxCraft.Smapi.Tests/Snapshots/SlotBuilderTests.Build_WithSamplesAndRequired_CombinesPropertiesCorrectly.verified.json
@@ -1,0 +1,9 @@
+﻿{
+  "Name": "productCategory",
+  "Type": "factType",
+  "IsRequired": true,
+  "Samples": [
+    "{productCategory} pack",
+    "Tell me about a {productCategory} pack"
+  ]
+}

--- a/test/AlexaVoxCraft.Smapi.Tests/Snapshots/SlotBuilderTests.Build_WithSingleSample_IncludesSampleInResult.verified.json
+++ b/test/AlexaVoxCraft.Smapi.Tests/Snapshots/SlotBuilderTests.Build_WithSingleSample_IncludesSampleInResult.verified.json
@@ -1,0 +1,8 @@
+﻿{
+  "Name": "productCategory",
+  "Type": "factType",
+  "IsRequired": false,
+  "Samples": [
+    "{productCategory} pack"
+  ]
+}


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary

Adds support for per-slot sample utterances in the `AlexaVoxCraft.Smapi` interaction model builder. The Alexa SMAPI interaction model allows slots within an intent to declare their own `samples` array (example utterances showing the slot used in context), but `IntentSlot` and `SlotBuilder` had no way to express this.

**Changes:**
- Added `Samples` property (`IReadOnlyList<string>?`) to `IntentSlot` model with `JsonIgnore(WhenWritingNull)` so it is omitted when not set
- Added `WithSample(string)` and `WithSamples(params string[])` fluent methods to `SlotBuilder`, matching the existing pattern on `IntentBuilder`

**Usage:**
```csharp
.AddIntent("ProductDetailIntent", intent => intent
    .WithSlot("productCategory", "factType", slot => slot
        .WithSamples(
            "{productCategory} pack",
            "Tell me about a {productCategory} pack"))
    .WithSamples("tell me more about {productCategory} pack", ...))
```

---

## ✅ Checklist

- [x] My changes build cleanly
- [x] I've added/updated relevant tests
- [ ] I've added/updated documentation or README
- [x] I've followed the coding style for this project
- [x] I've tested the changes locally (if applicable)

---

## 🧪 Related Issues or PRs

Closes #...

---

## 💬 Notes for Reviewers

- `Samples` is nullable and omitted from JSON when empty — no breaking change for existing slot definitions
- 5 new snapshot tests cover: no samples, single sample, multiple via `WithSample`, multiple via `WithSamples`, and combined with `Required()`