### PR TITLE
feat(core): add APL document versions 2023.3, 2024.2, and 2024.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>7.0.1-beta</VersionPrefix>
+        <VersionPrefix>7.0.2-beta</VersionPrefix>
         <!-- SPDX license identifier for Apache 2.0 -->
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 

--- a/src/AlexaVoxCraft.Model.Apl/APLDocumentVersion.cs
+++ b/src/AlexaVoxCraft.Model.Apl/APLDocumentVersion.cs
@@ -36,6 +36,12 @@ public enum APLDocumentVersion
     V2023_1,
     [EnumMember(Value = "2023.2")]
     V2023_2,
+    [EnumMember(Value = "2023.3")]
+    V2023_3,
     [EnumMember(Value = "2024.1")]
-    V2024_1
+    V2024_1,
+    [EnumMember(Value = "2024.2")]
+    V2024_2,
+    [EnumMember(Value = "2024.3")]
+    V2024_3
 }


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary

Adds three missing APL document specification versions to the `APLDocumentVersion` enum:
- `V2023_3` (`2023.3`)
- `V2024_2` (`2024.2`)
- `V2024_3` (`2024.3`)

Also bumps `VersionPrefix` from `7.0.1-beta` to `7.0.2-beta` to reflect the additive change.

---

## ✅ Checklist

- [ ] My changes build cleanly
- [ ] I've added/updated relevant tests
- [ ] I've added/updated documentation or README
- [ ] I've followed the coding style for this project
- [ ] I've tested the changes locally (if applicable)

---

## 🧪 Related Issues or PRs

N/A

---

## 💬 Notes for Reviewers

Purely additive change — existing enum values and serialization are unchanged. The new entries follow the same `[EnumMember(Value = "...")]` pattern as all existing values.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)