### PR TITLE
fix(deps): revert Microsoft.CodeAnalysis.CSharp to 5.0.0 to restore interceptor compatibility

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>7.0.4</VersionPrefix>
+        <VersionPrefix>7.0.5</VersionPrefix>
         <!-- SPDX license identifier for Apache 2.0 -->
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,7 +49,7 @@
   </ItemGroup>
   <ItemGroup Label="Roslyn / Source Generators">
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Label="Verify">
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />


### PR DESCRIPTION
## Summary

- `Microsoft.CodeAnalysis.CSharp` was updated to 5.3.0 as part of a routine package update but broke the `InterceptsLocation` interceptor mechanism in consuming applications
- Reverted to 5.0.0 which is the last known-good version for the source generator interception pattern
- Version bump `7.0.4` → `7.0.5`

## Changes

- **`Directory.Packages.props`**: `Microsoft.CodeAnalysis.CSharp` `5.3.0` → `5.0.0`
- **`Directory.Build.props`**: `VersionPrefix` `7.0.4` → `7.0.5`

## Related Issues

None

## Reviewer Notes

`Microsoft.CodeAnalysis.Analyzers` remains at 5.3.0 — only the `CSharp` package needed rolling back. If/when 5.3.0 is re-evaluated, interception behaviour in consuming skill applications should be validated end-to-end before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)