### PR TITLE
fix(isp)!: require upsellMessage in UpsellDirective constructor

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>7.1.0</VersionPrefix>
+        <VersionPrefix>7.2.0</VersionPrefix>
         <!-- SPDX license identifier for Apache 2.0 -->
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -71,6 +71,6 @@
     <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.4" />
   </ItemGroup>
   <ItemGroup Label="Utilities">
-    <PackageVersion Include="MinimalLambda" Version="2.2.0" />
+    <PackageVersion Include="MinimalLambda" Version="2.3.1" />
   </ItemGroup>
 </Project>

--- a/samples/Sample.Fact.InSkill.Purchases/Handlers/GetCategoryFactHandler.cs
+++ b/samples/Sample.Fact.InSkill.Purchases/Handlers/GetCategoryFactHandler.cs
@@ -88,10 +88,7 @@ public class GetCategoryFactHandler : IRequestHandler<IntentRequest>
                     {
                         var upsellMessage = $"You don't currently own the {factCategory} pack. {categoryProduct.Summary} Want to learn more?";
                         return await input.ResponseBuilder
-                            .AddDirective(new UpsellDirective(categoryProduct.ProductId, "correlationToken")
-                            {
-                                Payload = new(categoryProduct.ProductId, upsellMessage)
-                            })
+                            .AddDirective(new UpsellDirective(categoryProduct.ProductId, upsellMessage, "correlationToken"))
                             .GetResponse(cancellationToken);
                     }
 

--- a/src/AlexaVoxCraft.Model.InSkillPurchasing/Directives/UpsellDirective.cs
+++ b/src/AlexaVoxCraft.Model.InSkillPurchasing/Directives/UpsellDirective.cs
@@ -4,6 +4,7 @@ namespace AlexaVoxCraft.Model.InSkillPurchasing.Directives;
 /// Directive that initiates the Alexa in-skill purchasing Upsell flow for the specified product.
 /// </summary>
 /// <param name="productId">The unique identifier of the in-skill product to upsell.</param>
-/// <param name="token">An optional correlation token returned in the resulting <c>Connections.Response</c>.</param>
-public class UpsellDirective(string? productId = null, string? token = null)
-    : PaymentDirective(PaymentType.Upsell, token, new PaymentPayload(productId));
+/// <param name="upsellMessage">The message presented to the user during the upsell flow.</param>
+/// <param name="token">A correlation token returned in the resulting <c>Connections.Response</c>.</param>
+public class UpsellDirective(string productId, string upsellMessage, string token)
+    : PaymentDirective(PaymentType.Upsell, token, new PaymentPayload(productId, upsellMessage));

--- a/test/AlexaVoxCraft.Model.InSkillPurchasing.Tests/Directive/UpsellDirectiveTests.cs
+++ b/test/AlexaVoxCraft.Model.InSkillPurchasing.Tests/Directive/UpsellDirectiveTests.cs
@@ -7,7 +7,7 @@ public class UpsellDirectiveTests : TestBase<UpsellDirectiveTests>
     [Fact]
     public async Task UpsellDirective_Serializes()
     {
-        var directive = new UpsellDirective("amzn1.adg.product", "correlationToken");
+        var directive = new UpsellDirective("amzn1.adg.product", "This is a great offer!", "correlationToken");
         await TestHelper.VerifySerializedObject(directive, AlexaJson, "UpsellDirective");
     }
 }

--- a/test/AlexaVoxCraft.Model.InSkillPurchasing.Tests/Snapshots/UpsellDirectiveTests.UpsellDirective_Serializes.verified.txt
+++ b/test/AlexaVoxCraft.Model.InSkillPurchasing.Tests/Snapshots/UpsellDirectiveTests.UpsellDirective_Serializes.verified.txt
@@ -1,1 +1,1 @@
-﻿{"token":"correlationToken","payload":{"InSkillProduct":{"productId":"amzn1.adg.product"}},"type":"Connections.SendRequest","name":"Upsell"}
+﻿{"token":"correlationToken","payload":{"InSkillProduct":{"productId":"amzn1.adg.product"},"upsellMessage":"This is a great offer!"},"type":"Connections.SendRequest","name":"Upsell"}


### PR DESCRIPTION
## Summary

`UpsellDirective` was missing `upsellMessage` as a constructor parameter — callers had no way to set it without manually overriding the `Payload` property after construction. All three parameters (`productId`, `upsellMessage`, `token`) are now required and non-nullable, with `upsellMessage` passed directly through to `PaymentPayload`. Version bumped to `7.2.0`.

## Changes

**`UpsellDirective`**
- Constructor signature changed from `(string? productId, string? token)` to `(string productId, string upsellMessage, string token)` — all params required and non-nullable
- `upsellMessage` forwarded to `PaymentPayload` constructor

**`GetCategoryFactHandler` (sample)**
- Updated call site to pass `upsellMessage` as second argument; removed redundant manual `Payload` override

**Tests**
- Updated `UpsellDirectiveTests` constructor call to include `upsellMessage`
- Updated verified snapshot to include `"upsellMessage"` in serialized output

**Version**
- `Directory.Build.props`: `7.1.0` → `7.2.0`

## Validation

- Serialization snapshot updated and verified to include `upsellMessage` in the JSON payload
- Existing `UpsellDirective_Serializes` test updated to pass with new signature

## Breaking Changes

`UpsellDirective` constructor signature has changed:

```csharp
// Before
new UpsellDirective("product-id", "correlationToken")

// After
new UpsellDirective("product-id", "Your upsell message here.", "correlationToken")
```

Callers must add `upsellMessage` as the second argument. Any code that previously set `Payload` manually to include a `upsellMessage` can be simplified to use the constructor directly.

## Release Notes

**Breaking:** `UpsellDirective` now requires `upsellMessage` as a constructor parameter. Previously this field was silently omitted from the payload unless callers manually overrode the `Payload` property.

🤖 Generated with [Claude Code](https://claude.ai/code)