### PR TITLE
feat(smapi): add multi-locale interaction model builder with default locale fallback

### DIFF
--- a/AlexaVoxCraft.slnx
+++ b/AlexaVoxCraft.slnx
@@ -9,6 +9,14 @@
     <File Path="mkdocs.yml" />
     <File Path="requirements.txt" />
   </Folder>
+  <Folder Name="/docs/adr/">
+    <File Path="docs/adr/README.md" />
+    <File Path="docs/adr/0000-adr-template.md" />
+    <File Path="docs/adr/0001-multi-locale-interaction-model-builder.md" />
+  </Folder>
+  <Folder Name="/docs/plans/">
+    <File Path="docs/plans/multi-locale-interaction-model-builder-plan.md" />
+  </Folder>
   <Folder Name="/docs/assets/">
     <File Path="docs/assets/icon.png" />
   </Folder>
@@ -133,6 +141,7 @@
     <Project Path="test/AlexaVoxCraft.Model.Apl.Tests/AlexaVoxCraft.Model.Apl.Tests.csproj" />
     <Project Path="test/AlexaVoxCraft.Model.InSkillPurchasing.Tests/AlexaVoxCraft.Model.InSkillPurchasing.Tests.csproj" />
     <Project Path="test/AlexaVoxCraft.Smapi.Tests/AlexaVoxCraft.Smapi.Tests.csproj" />
+    <File Path="test/AlexaVoxCraft.Smapi.Tests/Builders/InteractionModel/MultiLocaleInteractionModelBuilderTests.cs" />
     <Project Path="test/AlexaVoxCraft.TestKit/AlexaVoxCraft.TestKit.csproj" />
     <Project Path="test\AlexaVoxCraft.Model.Apl.Legacy.Tests\AlexaVoxCraft.Model.Apl.Legacy.Tests.csproj">
       <Configuration Solution="Debug|x64" Project="Debug|Any CPU" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>7.2.0</VersionPrefix>
+        <VersionPrefix>7.3.0</VersionPrefix>
         <!-- SPDX license identifier for Apache 2.0 -->
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 

--- a/docs/adr/0000-adr-template.md
+++ b/docs/adr/0000-adr-template.md
@@ -1,0 +1,69 @@
+# [ADR-NNNN] Title
+
+**Status:** [Proposed | Accepted | Deprecated | Superseded by ADR-XXXX]
+
+**Date:** YYYY-MM-DD
+
+**Decision Makers:** [List of people involved in the decision]
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change? Describe the forces at play (technical, political, social, project-specific).
+
+## Decision Drivers
+
+- [Driver 1, e.g., performance requirement]
+- [Driver 2, e.g., cost constraint]
+- [Driver 3, e.g., team expertise]
+- [Driver 4, e.g., time to market]
+
+## Considered Options
+
+1. [Option 1]
+2. [Option 2]
+3. [Option 3]
+
+## Decision Outcome
+
+Chosen option: "[Option X]", because [justification. e.g., best balance of forces, most aligned with constraints].
+
+### Positive Consequences
+
+- [Benefit 1]
+- [Benefit 2]
+
+### Negative Consequences
+
+- [Drawback 1, with mitigation if applicable]
+- [Drawback 2]
+
+## Pros and Cons of the Options
+
+### [Option 1]
+
+[Description of option 1]
+
+- Good, because [argument a]
+- Good, because [argument b]
+- Bad, because [argument c]
+
+### [Option 2]
+
+[Description of option 2]
+
+- Good, because [argument d]
+- Bad, because [argument e]
+- Bad, because [argument f]
+
+### [Option 3]
+
+[Description of option 3]
+
+- Good, because [argument g]
+- Bad, because [argument h]
+
+## Links
+
+- [Related ADR or document]
+- [External reference or documentation]
+- [GitHub issue or PR that triggered this decision]

--- a/docs/adr/0001-multi-locale-interaction-model-builder.md
+++ b/docs/adr/0001-multi-locale-interaction-model-builder.md
@@ -1,0 +1,90 @@
+# [ADR-0001] Multi-Locale Interaction Model Builder with Default Locale Fallback
+
+**Status:** Accepted
+
+**Date:** 2026-03-25
+
+**Decision Makers:** Nick Cipollina
+
+## Context
+
+The `AlexaVoxCraft.Smapi` package provides an `InteractionModelBuilder` for constructing Alexa interaction model definitions in code. The `AlexaInteractionModelClient` already accepts a `locale` parameter on its `GetAsync` and `UpdateAsync` methods, reflecting the SMAPI API's per-locale model structure.
+
+However, the builder has no concept of locale. Callers building skills that support multiple locales (e.g., en-US, en-GB, en-CA) must construct entirely separate `InteractionModelBuilder` instances for each locale, duplicating all intent names, slot definitions, slot type names, and built-in intent registrations. Only sample utterances and invocation names legitimately differ between locales — yet everything must be repeated.
+
+This creates noise, increases the chance of structural drift between locales, and makes multi-locale skill maintenance difficult.
+
+## Decision Drivers
+
+- Alexa skills commonly target multiple English locales (en-US, en-GB, en-CA, en-AU) with near-identical intent schemas but locale-specific invocation names and sample utterances
+- Structural elements (intent names, slot names, slot type names, built-in intents) are always identical across locales
+- The only genuinely locale-specific content is: invocation name, intent sample utterances, slot-level samples, and slot type values/synonyms
+- Developer ergonomics: defining shared structure once and only overriding what differs is the familiar `.resx` resource file mental model
+- Existing `InteractionModelBuilder` must remain backward compatible — no breaking changes
+
+## Considered Options
+
+1. **`MultiLocaleInteractionModelBuilder` with shared schema and per-locale overrides (default locale fallback)**
+2. **Per-locale `InteractionModelBuilder` instances with no coordination**
+3. **Single `InteractionModelBuilder` with a locale collection and locale-keyed sample dictionaries**
+
+## Decision Outcome
+
+Chosen option: **Option 1**, because it eliminates structural duplication, makes locale-specific content explicit and minimal, and follows the well-understood resource file fallback model (base culture → specific culture).
+
+A `WithDefaultLocale` method establishes the base locale (included in output). `ForLocale` registers additional locales that inherit all unoverridden values from the default. `BuildAll()` merges and produces an `IReadOnlyList<LocalizedInteractionModel>` ready to push via `UpdateAllAsync`.
+
+### Positive Consequences
+
+- Intent names, slot definitions, slot types, and built-in intents are declared once
+- Only invocation names and utterances need to be written per locale — the actual delta
+- Adding a new locale that is identical to the default requires a single `.ForLocale("en-CA")` call with no lambda
+- Validation of locale-specific content (unknown intent names, unknown slot types) fails fast at call time, not at build time
+- `LocalizedInteractionModel` record cleanly pairs locale + definition for use with the client's new overloads
+- Fully backward compatible — `InteractionModelBuilder.Build()` and `ToJson()` are unchanged
+- `UpdateAllAsync` provides a natural batch push of all locales in a single call
+
+### Negative Consequences
+
+- The `MultiLocaleInteractionModelBuilder` is a larger surface area than the single builder — more types to understand (`LocaleOverrideBuilder`, `LocalizedInteractionModel`)
+- Callers who need fully independent schemas per locale (e.g., completely different intent structures for different languages) must still use separate `InteractionModelBuilder` instances; the multi-locale builder assumes a shared schema
+- `AddSlotType` on `MultiLocaleInteractionModelBuilder` makes `configure` optional (unlike the single builder where it is required), which is a subtle API inconsistency — justified because slot values are locale-specific and often not set at the schema level
+
+## Pros and Cons of the Options
+
+### Option 1: `MultiLocaleInteractionModelBuilder` with shared schema and default locale fallback
+
+A new builder class where structural elements (intents, slot types) are defined once. A `WithDefaultLocale` call establishes base locale text. `ForLocale` calls register additional locales with only their overrides. `BuildAll()` merges per locale using fallback resolution: locale value → default value.
+
+- Good, because structural elements are never duplicated
+- Good, because the fallback model is familiar from .resx / resource file conventions
+- Good, because `.ForLocale("en-CA")` with no lambda is valid and produces a model identical to the default
+- Good, because validation fails at the call site (wrong intent name in `WithIntentSamples`) not at build time
+- Good, because `UpdateAllAsync` enables batch push of all locales sequentially, respecting SMAPI rate limits
+- Bad, because adds new types (`LocaleOverrideBuilder`, `LocalizedInteractionModel`, `MultiLocaleInteractionModelBuilder`)
+- Bad, because assumes a shared schema — callers with truly divergent locale schemas must use a different approach
+
+### Option 2: Per-locale `InteractionModelBuilder` instances with no coordination
+
+Callers create independent `InteractionModelBuilder` instances per locale and push each separately.
+
+- Good, because no new types required — callers already know `InteractionModelBuilder`
+- Good, because locales are completely independent — no shared state surprises
+- Bad, because every intent name, built-in intent, and slot definition must be repeated for each locale
+- Bad, because structural drift between locales is easy and silent — a renamed intent in one locale is not reflected in others
+- Bad, because pushing multiple locales requires manual iteration
+
+### Option 3: Single `InteractionModelBuilder` with locale-keyed sample dictionaries
+
+Extend the existing builder with methods like `WithIntentSamples("en-US", "OrderIntent", ...)` and a `BuildAll()` that emits one definition per registered locale.
+
+- Good, because stays within a single builder type
+- Bad, because mixes structural and locale-specific concerns in one object — the builder becomes large and harder to reason about
+- Bad, because the locale string becomes a stringly-typed parameter on every call, increasing error surface
+- Bad, because no clean concept of a "default" locale — every locale must fully specify its samples
+
+## Links
+
+- [Implementation Plan](../plans/multi-locale-interaction-model-builder-plan.md)
+- [SMAPI Interaction Model API](https://developer.amazon.com/en-US/docs/alexa/smapi/interaction-model-schema.html)
+- [Alexa Interaction Model Locale Support](https://developer.amazon.com/en-US/docs/alexa/custom-skills/develop-skills-in-multiple-languages.html)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,44 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for the AlexaVoxCraft project.
+
+## What is an ADR?
+
+An Architecture Decision Record captures an important architectural decision made along with its context and consequences. ADRs help preserve institutional knowledge and provide context for future developers.
+
+## Index
+
+| ADR | Title | Status | Date |
+|-----|-------|--------|------|
+| [0000](0000-adr-template.md) | ADR Template | - | - |
+| [0001](0001-multi-locale-interaction-model-builder.md) | Multi-Locale Interaction Model Builder | Accepted | 2026-03-25 |
+
+## Creating a New ADR
+
+1. Copy `0000-adr-template.md` to a new file with the next sequential number
+2. Fill in all template sections
+3. Update this README index
+4. Submit for review via PR
+
+## When to Write an ADR
+
+Write an ADR when making decisions about:
+
+- Significant technology choices (frameworks, databases, protocols)
+- Architectural patterns (CQRS, event sourcing, microservices)
+- Non-obvious decisions that future developers might question
+- Decisions with long-term consequences
+- Trade-offs between competing approaches
+
+## ADR Lifecycle
+
+- **Proposed**: Under discussion, not yet accepted
+- **Accepted**: Decision has been made and implemented
+- **Deprecated**: No longer applies but kept for historical context
+- **Superseded**: Replaced by a newer ADR (link to replacement)
+
+## Maintenance
+
+- Review ADRs quarterly to mark deprecated or superseded records
+- Include ADR review in PR checklist for architectural changes
+- Reference relevant ADRs in code comments when helpful

--- a/docs/plans/multi-locale-interaction-model-builder-plan.md
+++ b/docs/plans/multi-locale-interaction-model-builder-plan.md
@@ -1,0 +1,303 @@
+# Multi-Locale Interaction Model Builder — Implementation Plan
+
+**Related ADR:** [ADR-0001 — Multi-Locale Interaction Model Builder](../adr/0001-multi-locale-interaction-model-builder.md)
+**Date:** 2026-03-25
+
+---
+
+## Goals
+
+1. Add locale awareness to `InteractionModelBuilder` via `WithLocale` + `BuildLocalized()` (non-breaking).
+2. Introduce `MultiLocaleInteractionModelBuilder` with a shared schema and per-locale override model using a `.resx`-style default locale fallback.
+3. Add `LocalizedInteractionModel` as the pairing type (locale + definition) used throughout.
+4. Add `UpdateAsync(LocalizedInteractionModel)` and `UpdateAllAsync` convenience overloads to the client.
+
+---
+
+## New Files
+
+| File | Purpose |
+|---|---|
+| `src/AlexaVoxCraft.Smapi/Models/InteractionModel/LocalizedInteractionModel.cs` | Record pairing `Locale` + `InteractionModelDefinition` |
+| `src/AlexaVoxCraft.Smapi/Builders/InteractionModel/LocaleOverrideBuilder.cs` | Builder for locale-specific text overrides; validates against schema at call time |
+| `src/AlexaVoxCraft.Smapi/Builders/InteractionModel/MultiLocaleInteractionModelBuilder.cs` | Top-level orchestrator with shared schema, `WithDefaultLocale`, `ForLocale`, `BuildAll()` |
+| `test/AlexaVoxCraft.Smapi.Tests/Builders/InteractionModel/MultiLocaleInteractionModelBuilderTests.cs` | Snapshot + exception tests |
+
+---
+
+## Modified Files
+
+| File | Change |
+|---|---|
+| `src/.../Builders/InteractionModel/IntentBuilder.cs` | Add `internal` members: `Name`, `SlotNames`, `BuildWithSamples(samples)` |
+| `src/.../Builders/InteractionModel/SlotBuilder.cs` | Add `internal` members: `Name`, `BuildWithSamples(samples)` |
+| `src/.../Builders/InteractionModel/InteractionModelBuilder.cs` | Add `WithLocale(string)` + `BuildLocalized()` — `Build()` and `ToJson()` unchanged |
+| `src/.../Clients/IAlexaInteractionModelClient.cs` | Add `UpdateAsync(skillId, stage, LocalizedInteractionModel, ct)` + `UpdateAllAsync(...)` |
+| `src/.../Clients/AlexaInteractionModelClient.cs` | Implement the two new overloads |
+| `test/.../Builders/InteractionModel/InteractionModelBuilderTests.cs` | Add 2 tests for `BuildLocalized` and missing locale guard |
+| `test/.../Clients/AlexaInteractionModelClientTests.cs` | Add tests for new client overloads |
+
+---
+
+## Design
+
+### `LocalizedInteractionModel`
+
+```csharp
+public sealed record LocalizedInteractionModel(string Locale, InteractionModelDefinition Definition);
+```
+
+Not serialized as a unit — `Definition` is what gets PUT to SMAPI; `Locale` goes in the URL.
+
+---
+
+### `InteractionModelBuilder` additions (backward compatible)
+
+```csharp
+public InteractionModelBuilder WithLocale(string locale) { ... }
+
+// Throws if locale not set via WithLocale
+public LocalizedInteractionModel BuildLocalized() { ... }
+```
+
+`Build()` and `ToJson()` remain unchanged.
+
+---
+
+### `LocaleOverrideBuilder`
+
+Holds locale-specific overrides. Constructed internally by `MultiLocaleInteractionModelBuilder` and passed to the caller's `Action<LocaleOverrideBuilder>` lambda. Constructor is `internal`.
+
+Takes schema references (live dictionary references from the parent builder) so it can validate at call time.
+
+**Public API:**
+
+```csharp
+public LocaleOverrideBuilder WithInvocationName(string name);
+
+// Validates intentName exists in schema — throws if not
+public LocaleOverrideBuilder WithIntentSamples(string intentName, params string[] samples);
+
+// Validates intent + slot exist in schema — throws if not
+public LocaleOverrideBuilder WithSlotSamples(string intentName, string slotName, params string[] samples);
+
+// Validates slotTypeName exists in schema — throws if not
+public LocaleOverrideBuilder WithSlotValues(string slotTypeName, Action<SlotTypeBuilder> configure);
+```
+
+Override semantics are **replacement**, not accumulation — locale overrides declare the full locale-specific set, not additions to the default.
+
+---
+
+### `MultiLocaleInteractionModelBuilder`
+
+```csharp
+public sealed class MultiLocaleInteractionModelBuilder
+{
+    public static MultiLocaleInteractionModelBuilder Create();
+
+    // Shared metadata
+    public MultiLocaleInteractionModelBuilder WithVersion(string version);
+    public MultiLocaleInteractionModelBuilder WithDescription(string description);
+
+    // Shared schema (structure only — no samples at this level)
+    public MultiLocaleInteractionModelBuilder AddIntent(string name, Action<IntentBuilder>? configure = null);
+    public MultiLocaleInteractionModelBuilder AddSlotType(string name, Action<SlotTypeBuilder>? configure = null);
+    public MultiLocaleInteractionModelBuilder WithNameFreeInteraction(Action<NameFreeInteractionBuilder>? configure = null);
+
+    // Default locale — base resource file; included in BuildAll() output
+    public MultiLocaleInteractionModelBuilder WithDefaultLocale(string locale, Action<LocaleOverrideBuilder> configure);
+
+    // Additional locales — null/no lambda means inherit everything from default
+    public MultiLocaleInteractionModelBuilder ForLocale(string locale, Action<LocaleOverrideBuilder>? configure = null);
+
+    // Merges default + overrides per locale; throws if no default locale set
+    public IReadOnlyList<LocalizedInteractionModel> BuildAll();
+}
+```
+
+**Notes:**
+- `AddSlotType` makes `configure` optional (unlike single builder) — slot values are locale-specific and often not set at the schema level
+- `ForLocale` with a locale matching `_defaultLocale` applies the configure to `_defaultOverrides` directly
+- Duplicate `ForLocale` calls for the same locale merge into the same `LocaleOverrideBuilder`
+- Output order: default locale first, then `ForLocale` registrations in insertion order
+
+---
+
+### `BuildAll()` merge algorithm
+
+```
+1. Guard: no WithDefaultLocale called → InvalidOperationException("A default locale must be specified using WithDefaultLocale.")
+2. Guard: version/description not set → same as InteractionModelBuilder.Build()
+3. Enumerate all locales: [defaultLocale] + forLocale registrations (in insertion order, deduped)
+4. For each locale:
+   a. Resolve invocationName:   locale override → default
+   b. For each intent, resolve samples:  locale override → default
+   c. For each intent's slot, resolve slot samples:  locale override → default
+   d. For each slot type, resolve values:  locale override → default
+   e. Build LanguageModel → InteractionModelBody → InteractionModelDefinition
+   f. Emit LocalizedInteractionModel(locale, definition)
+```
+
+---
+
+### Internal additions to `IntentBuilder` and `SlotBuilder`
+
+These are `internal` — not part of the public API.
+
+**`IntentBuilder`:**
+```csharp
+internal string Name { get; }
+internal IReadOnlyCollection<string> SlotNames { get; }
+
+// Builds the intent with caller-supplied samples instead of accumulated _samples
+// Reuses slot structure unchanged
+internal Intent BuildWithSamples(IReadOnlyList<string> samples);
+```
+
+**`SlotBuilder`:**
+```csharp
+internal string Name { get; }
+
+// Builds the slot with caller-supplied samples
+internal IntentSlot BuildWithSamples(IReadOnlyList<string> samples);
+```
+
+`BuildWithSamples` avoids mutating shared builder state — builders remain idempotent and `BuildAll()` can be called multiple times safely.
+
+---
+
+### Client additions
+
+```csharp
+// IAlexaInteractionModelClient
+Task UpdateAsync(string skillId, string stage, LocalizedInteractionModel model, CancellationToken ct);
+Task UpdateAllAsync(string skillId, string stage, IEnumerable<LocalizedInteractionModel> models, CancellationToken ct);
+
+// AlexaInteractionModelClient
+public Task UpdateAsync(string skillId, string stage, LocalizedInteractionModel model, CancellationToken ct)
+    => UpdateAsync(skillId, stage, model.Locale, model.Definition, ct);
+
+public async Task UpdateAllAsync(string skillId, string stage, IEnumerable<LocalizedInteractionModel> models, CancellationToken ct)
+{
+    var errors = new List<Exception>();
+    foreach (var model in models)
+    {
+        ct.ThrowIfCancellationRequested();
+        try
+        {
+            await UpdateAsync(skillId, stage, model, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            errors.Add(ex);
+        }
+    }
+
+    if (errors.Count > 0)
+        throw new AggregateException($"Failed to update {errors.Count} locale(s).", errors);
+}
+```
+
+Sequential execution — no parallelism — to respect SMAPI rate limits. All locales are attempted regardless of individual failures; errors are collected and thrown together as an `AggregateException` at the end. `OperationCanceledException` propagates immediately to honour cancellation.
+
+---
+
+## Validation Rules
+
+| Guard | When | Exception |
+|---|---|---|
+| No `WithDefaultLocale` | `BuildAll()` | `"A default locale must be specified using WithDefaultLocale."` |
+| Missing version | `BuildAll()` | `"Interaction model version must be specified."` |
+| Missing description | `BuildAll()` | `"Interaction model description must be specified."` |
+| Unknown intent name | `WithIntentSamples` / `WithSlotSamples` call time | `"Intent '{name}' is not defined in the interaction model schema."` |
+| Unknown slot name | `WithSlotSamples` call time | `"Slot '{slot}' is not defined on intent '{intent}'."` |
+| Unknown slot type | `WithSlotValues` call time | `"Slot type '{name}' is not defined in the interaction model schema."` |
+| Missing locale | `BuildLocalized()` (single builder) | `"A locale must be specified using WithLocale."` |
+
+---
+
+## Typical Usage
+
+```csharp
+// Single locale (additive to existing API)
+InteractionModelBuilder.Create()
+    .WithLocale("en-US")
+    .WithInvocationName("my skill")
+    .WithVersion("1").WithDescription("...")
+    .AddIntent("OrderIntent", i => i.WithSamples("order {drink}"))
+    .BuildLocalized(); // → LocalizedInteractionModel
+
+// Multi-locale
+var models = MultiLocaleInteractionModelBuilder.Create()
+    .WithVersion("1").WithDescription("My skill")
+    .AddIntent("OrderIntent", i => i.WithSlot("drink", "DrinkType"))
+    .AddIntent(BuiltInIntent.Cancel)
+    .AddIntent(BuiltInIntent.Stop)
+    .AddSlotType("DrinkType")
+    .WithDefaultLocale("en-US", locale => locale
+        .WithInvocationName("my skill")
+        .WithIntentSamples("OrderIntent", "order {drink}", "get {drink}")
+        .WithSlotValues("DrinkType", v => v.WithValue("coffee").WithValue("tea")))
+    .ForLocale("en-CA")                                  // inherits everything
+    .ForLocale("en-GB", locale => locale
+        .WithIntentSamples("OrderIntent", "order {drink}", "I'd like {drink}"))
+    .BuildAll();
+// → [en-US, en-CA (identical to en-US), en-GB (different samples)]
+
+await client.UpdateAllAsync(skillId, "development", models, ct);
+```
+
+---
+
+## Test Coverage
+
+### `MultiLocaleInteractionModelBuilderTests` (new)
+
+| Test | Type |
+|---|---|
+| `BuildAll_WithSingleDefaultLocale_ReturnsOneModel` | Snapshot |
+| `BuildAll_WithMultipleLocales_ReturnsAllLocales` | Snapshot |
+| `BuildAll_LocaleOverridingInvocationName_UsesOverrideForThatLocale` | Snapshot |
+| `BuildAll_WithIntentSamplesOverride_AppliesOverrideForLocale` | Snapshot |
+| `BuildAll_WithSlotSamplesOverride_AppliesOverrideForLocale` | Snapshot |
+| `BuildAll_WithSlotValuesOverride_AppliesOverrideForLocale` | Snapshot |
+| `BuildAll_WithForLocaleAndNoLambda_InheritsAllFromDefault` | Snapshot |
+| `BuildAll_WithDuplicateForLocale_MergesIntoSameBuilder` | Snapshot |
+| `BuildAll_WithNoDefaultLocale_ThrowsInvalidOperationException` | Exception |
+| `WithIntentSamples_ForUnknownIntent_ThrowsInvalidOperationException` | Exception |
+| `WithSlotSamples_ForUnknownSlot_ThrowsInvalidOperationException` | Exception |
+| `WithSlotValues_ForUnknownSlotType_ThrowsInvalidOperationException` | Exception |
+
+### `InteractionModelBuilderTests` additions
+
+| Test | Type |
+|---|---|
+| `BuildLocalized_WithLocale_ReturnsLocalizedModel` | Assertion |
+| `BuildLocalized_WithoutLocale_ThrowsInvalidOperationException` | Exception |
+
+### `AlexaInteractionModelClientTests` additions
+
+| Test | Type |
+|---|---|
+| `UpdateAsync_WithLocalizedModel_CallsCorrectEndpoint` | Mock assertion |
+| `UpdateAllAsync_WithMultipleModels_CallsEndpointForEach` | Mock assertion |
+| `UpdateAllAsync_WithEmptyModels_CompletesWithoutCalling` | Mock assertion |
+| `UpdateAllAsync_WhenSomeLocalesFail_ThrowsAggregateExceptionAfterAttemptingAll` | Exception + mock assertion |
+
+---
+
+## Implementation Order
+
+1. `LocalizedInteractionModel.cs` — no dependencies
+2. `internal` additions to `IntentBuilder.cs` and `SlotBuilder.cs`
+3. `LocaleOverrideBuilder.cs` — depends on #2
+4. `MultiLocaleInteractionModelBuilder.cs` — depends on #3
+5. `InteractionModelBuilder.cs` additions — depends on #1
+6. `IAlexaInteractionModelClient.cs` additions — depends on #1
+7. `AlexaInteractionModelClient.cs` implementations — depends on #6
+8. Test files — depend on all of the above

--- a/docs/smapi/developer-client.md
+++ b/docs/smapi/developer-client.md
@@ -117,37 +117,62 @@ public class SkillDeploymentService
         _client = client;
     }
 
-    public async Task<string> UpdateInteractionModelAsync(
+    public async Task UpdateAsync(
         string skillId,
         string locale,
         InteractionModelDefinition model,
         CancellationToken cancellationToken = default)
     {
-        return await _client.UpdateInteractionModelAsync(
-            skillId,
-            "development",
-            locale,
-            model,
-            cancellationToken);
+        await _client.UpdateAsync(skillId, "development", locale, model, cancellationToken);
     }
 
-    public async Task<InteractionModelDefinition?> GetInteractionModelAsync(
+    public async Task<InteractionModelDefinition?> GetAsync(
         string skillId,
         string locale,
         CancellationToken cancellationToken = default)
     {
-        return await _client.GetInteractionModelAsync(
-            skillId,
-            "development",
-            locale,
-            cancellationToken);
+        return await _client.GetAsync(skillId, "development", locale, cancellationToken);
     }
+}
+```
+
+#### Deploying a Single Localized Model
+
+Use the `LocalizedInteractionModel` overload when you already have a locale paired with its definition:
+
+```csharp
+var localizedModel = new LocalizedInteractionModel("en-US", definition);
+await _client.UpdateAsync(skillId, "development", localizedModel, cancellationToken);
+```
+
+#### Deploying Multiple Locales
+
+`UpdateAllAsync` attempts every locale and collects failures into an `AggregateException` rather than stopping at the first error, ensuring all locales are always attempted:
+
+```csharp
+var models = new[]
+{
+    new LocalizedInteractionModel("en-US", enUsDefinition),
+    new LocalizedInteractionModel("en-GB", enGbDefinition),
+    new LocalizedInteractionModel("en-CA", enCaDefinition),
+};
+
+try
+{
+    await _client.UpdateAllAsync(skillId, "development", models, cancellationToken);
+}
+catch (AggregateException ex)
+{
+    foreach (var inner in ex.InnerExceptions)
+        Console.Error.WriteLine(inner.Message);
 }
 ```
 
 ### Building Interaction Models
 
-Use the fluent builder API to construct interaction models:
+#### Single-Locale Builder
+
+Use `InteractionModelBuilder` to construct a model for a single locale:
 
 ```csharp
 using AlexaVoxCraft.Smapi.Builders.InteractionModel;
@@ -177,6 +202,71 @@ var model = InteractionModelBuilder.Create()
             .WithValue("cheese", v => v.WithSynonyms("plain")))
     .Build();
 ```
+
+Use `WithLocale` and `BuildLocalized` to produce a `LocalizedInteractionModel` directly, ready for upload:
+
+```csharp
+var localized = InteractionModelBuilder.Create()
+    .WithLocale("en-US")
+    .WithInvocationName("my skill")
+    .WithVersion("1")
+    .WithDescription("My skill interaction model")
+    .AddIntent(BuiltInIntent.Help)
+    .AddIntent(BuiltInIntent.Cancel)
+    .BuildLocalized(); // returns LocalizedInteractionModel("en-US", ...)
+
+await _client.UpdateAsync(skillId, "development", localized, cancellationToken);
+```
+
+#### Multi-Locale Builder
+
+`MultiLocaleInteractionModelBuilder` lets you define the shared interaction model schema once (intent names, slot structure, slot type names) and specify locale-specific text per locale. Any text not overridden in an additional locale falls back to the default locale — similar to how `.resx` resource files work.
+
+**Schema-level** elements (defined once on the builder):
+- Intent names and slot structure
+- Slot type names
+
+**Locale-level** elements (defined per locale via `LocaleOverrideBuilder`):
+- Invocation name
+- Intent sample utterances
+- Slot sample utterances
+- Slot type values
+
+```csharp
+using AlexaVoxCraft.Smapi.Builders.InteractionModel;
+using AlexaVoxCraft.Model.Request.Type;
+
+var models = MultiLocaleInteractionModelBuilder.Create()
+    .WithVersion("1")
+    .WithDescription("My multi-locale skill")
+    // Define the schema once — slot structure shared across all locales
+    .AddIntent("OrderIntent", i => i.WithSlot("drink", "DrinkType"))
+    .AddIntent(BuiltInIntent.Cancel)
+    .AddIntent(BuiltInIntent.Stop)
+    .AddSlotType("DrinkType")
+    // Default locale provides the base text all other locales fall back to
+    .WithDefaultLocale("en-US", locale => locale
+        .WithInvocationName("my skill")
+        .WithIntentSamples("OrderIntent", "order {drink}", "get me {drink}")
+        .WithSlotValues("DrinkType", v => v
+            .WithValue("coffee")
+            .WithValue("tea")))
+    // en-CA inherits everything from en-US
+    .ForLocale("en-CA")
+    // en-GB overrides only the samples that differ
+    .ForLocale("en-GB", locale => locale
+        .WithInvocationName("my british skill")
+        .WithIntentSamples("OrderIntent", "order {drink}", "I'd like {drink}")
+        .WithSlotValues("DrinkType", v => v
+            .WithValue("coffee")
+            .WithValue("tea")
+            .WithValue("biscuit")))
+    .BuildAll(); // IReadOnlyList<LocalizedInteractionModel>, default locale first
+
+await _client.UpdateAllAsync(skillId, "development", models, cancellationToken);
+```
+
+`BuildAll` always includes the default locale first, followed by additional locales in registration order. Calling `ForLocale` with no lambda inherits everything from the default locale. Calling `ForLocale` multiple times for the same locale merges the overrides.
 
 ### Name-Free Interactions
 
@@ -322,7 +412,7 @@ The client throws standard HTTP exceptions for API errors:
 ```csharp
 try
 {
-    await client.UpdateInteractionModelAsync(skillId, stage, locale, model);
+    await client.UpdateAsync(skillId, "development", locale, model, cancellationToken);
 }
 catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
 {
@@ -335,6 +425,21 @@ catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Unauthoriz
 catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.TooManyRequests)
 {
     // Rate limited - implement retry with backoff
+}
+```
+
+When deploying multiple locales via `UpdateAllAsync`, individual locale failures are collected and thrown together as an `AggregateException` after all locales have been attempted. A `CancellationToken` cancellation propagates immediately:
+
+```csharp
+try
+{
+    await client.UpdateAllAsync(skillId, "development", models, cancellationToken);
+}
+catch (AggregateException ex)
+{
+    Console.Error.WriteLine($"Failed to update {ex.InnerExceptions.Count} locale(s):");
+    foreach (var inner in ex.InnerExceptions)
+        Console.Error.WriteLine($"  {inner.Message}");
 }
 ```
 

--- a/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/IntentBuilder.cs
+++ b/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/IntentBuilder.cs
@@ -67,11 +67,13 @@ public sealed class IntentBuilder
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
         ArgumentException.ThrowIfNullOrWhiteSpace(type);
 
-        if (!_slotNames.Add(name))
+        if (_slotNames.Contains(name))
             throw new InvalidOperationException($"Slot '{name}' has already been added to intent '{_name}'.");
 
         var builder = new SlotBuilder(name, type);
         configure?.Invoke(builder);
+
+        _slotNames.Add(name);
         _slots.Add(builder);
         return this;
     }

--- a/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/IntentBuilder.cs
+++ b/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/IntentBuilder.cs
@@ -98,6 +98,8 @@ public sealed class IntentBuilder
 
     internal string Name => _name;
 
+    internal IReadOnlyList<string> Samples => _samples;
+
     internal IReadOnlyCollection<string> SlotNames => _slotNames;
 
     internal Intent BuildWithSamples(

--- a/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/IntentBuilder.cs
+++ b/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/IntentBuilder.cs
@@ -89,4 +89,26 @@ public sealed class IntentBuilder
             Slots = slots
         };
     }
+
+    internal string Name => _name;
+
+    internal IReadOnlyCollection<string> SlotNames => _slots.Select(static s => s.Name).ToList();
+
+    internal Intent BuildWithSamples(
+        IReadOnlyList<string> intentSamples,
+        Dictionary<string, IReadOnlyList<string>?> slotSampleOverrides)
+    {
+        var slots = _slots.Select(s =>
+        {
+            slotSampleOverrides.TryGetValue(s.Name, out var slotSamples);
+            return s.BuildWithSamples(slotSamples);
+        }).ToImmutableArray();
+
+        return new Intent
+        {
+            Name = _name,
+            Samples = [.. intentSamples],
+            Slots = slots
+        };
+    }
 }

--- a/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/IntentBuilder.cs
+++ b/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/IntentBuilder.cs
@@ -11,6 +11,7 @@ public sealed class IntentBuilder
     private readonly string _name;
     private readonly List<string> _samples = [];
     private readonly List<SlotBuilder> _slots = [];
+    private readonly HashSet<string> _slotNames = [];
 
     /// <summary>
     /// Initializes a new instance of the <see cref="IntentBuilder"/> class.
@@ -66,6 +67,9 @@ public sealed class IntentBuilder
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
         ArgumentException.ThrowIfNullOrWhiteSpace(type);
 
+        if (!_slotNames.Add(name))
+            throw new InvalidOperationException($"Slot '{name}' has already been added to intent '{_name}'.");
+
         var builder = new SlotBuilder(name, type);
         configure?.Invoke(builder);
         _slots.Add(builder);
@@ -92,7 +96,7 @@ public sealed class IntentBuilder
 
     internal string Name => _name;
 
-    internal IReadOnlyCollection<string> SlotNames => _slots.Select(static s => s.Name).ToList();
+    internal IReadOnlyCollection<string> SlotNames => _slotNames;
 
     internal Intent BuildWithSamples(
         IReadOnlyList<string> intentSamples,

--- a/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/InteractionModelBuilder.cs
+++ b/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/InteractionModelBuilder.cs
@@ -14,6 +14,7 @@ public sealed class InteractionModelBuilder
     private string _invocationName = string.Empty;
     private string? _version;
     private string? _description;
+    private string? _locale;
 
     private readonly Dictionary<string, IntentBuilder> _intents = [];
     private readonly Dictionary<string, SlotTypeBuilder> _slotTypes = [];
@@ -40,6 +41,19 @@ public sealed class InteractionModelBuilder
         _invocationName = invocationName;
         return this;
     }
+    /// <summary>
+    /// Sets the locale for this interaction model.
+    /// Required when calling <see cref="BuildLocalized"/>.
+    /// </summary>
+    /// <param name="locale">The locale code (e.g., "en-US", "en-GB").</param>
+    /// <returns>The current <see cref="InteractionModelBuilder"/>.</returns>
+    public InteractionModelBuilder WithLocale(string locale)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(locale);
+        _locale = locale;
+        return this;
+    }
+
     /// <summary>
     /// Sets the interaction model version.
     /// </summary>
@@ -169,6 +183,19 @@ public sealed class InteractionModelBuilder
             Version = _version,
             Description = _description
         };
+    }
+
+    /// <summary>
+    /// Builds the interaction model definition paired with the configured locale.
+    /// </summary>
+    /// <returns>A <see cref="LocalizedInteractionModel"/> containing the locale and built definition.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if no locale has been set via <see cref="WithLocale"/>.</exception>
+    public LocalizedInteractionModel BuildLocalized()
+    {
+        if (string.IsNullOrWhiteSpace(_locale))
+            throw new InvalidOperationException("A locale must be specified using WithLocale.");
+
+        return new LocalizedInteractionModel(_locale, Build());
     }
 
     /// <summary>

--- a/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/InteractionModelBuilder.cs
+++ b/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/InteractionModelBuilder.cs
@@ -41,6 +41,7 @@ public sealed class InteractionModelBuilder
         _invocationName = invocationName;
         return this;
     }
+
     /// <summary>
     /// Sets the locale for this interaction model.
     /// Required when calling <see cref="BuildLocalized"/>.

--- a/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/LocaleOverrideBuilder.cs
+++ b/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/LocaleOverrideBuilder.cs
@@ -1,0 +1,117 @@
+namespace AlexaVoxCraft.Smapi.Builders.InteractionModel;
+
+/// <summary>
+/// Builder for locale-specific text overrides within a <see cref="MultiLocaleInteractionModelBuilder"/>.
+/// Any value not overridden falls back to the default locale's value at build time.
+/// </summary>
+public sealed class LocaleOverrideBuilder
+{
+    private readonly IReadOnlyDictionary<string, IntentBuilder> _schemaIntents;
+    private readonly IReadOnlyDictionary<string, SlotTypeBuilder> _schemaSlotTypes;
+
+    private string? _invocationName;
+    private readonly Dictionary<string, IReadOnlyList<string>> _intentSamples = [];
+    private readonly Dictionary<string, Dictionary<string, IReadOnlyList<string>>> _slotSamples = [];
+    private readonly Dictionary<string, Action<SlotTypeBuilder>> _slotValueConfigs = [];
+
+    internal LocaleOverrideBuilder(
+        IReadOnlyDictionary<string, IntentBuilder> schemaIntents,
+        IReadOnlyDictionary<string, SlotTypeBuilder> schemaSlotTypes)
+    {
+        _schemaIntents = schemaIntents;
+        _schemaSlotTypes = schemaSlotTypes;
+    }
+
+    /// <summary>
+    /// Sets the invocation name for this locale.
+    /// </summary>
+    /// <param name="name">The locale-specific invocation name.</param>
+    /// <returns>The current <see cref="LocaleOverrideBuilder"/>.</returns>
+    public LocaleOverrideBuilder WithInvocationName(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        _invocationName = name;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the sample utterances for the specified intent in this locale.
+    /// Replaces any previously set samples for this intent in this locale.
+    /// </summary>
+    /// <param name="intentName">The intent name. Must be defined in the schema.</param>
+    /// <param name="samples">The locale-specific sample utterances.</param>
+    /// <returns>The current <see cref="LocaleOverrideBuilder"/>.</returns>
+    public LocaleOverrideBuilder WithIntentSamples(string intentName, params string[] samples)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(intentName);
+        ArgumentNullException.ThrowIfNull(samples);
+
+        if (!_schemaIntents.ContainsKey(intentName))
+            throw new InvalidOperationException($"Intent '{intentName}' is not defined in the interaction model schema.");
+
+        _intentSamples[intentName] = samples;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the sample utterances for the specified slot in this locale.
+    /// Replaces any previously set samples for this slot in this locale.
+    /// </summary>
+    /// <param name="intentName">The intent name. Must be defined in the schema.</param>
+    /// <param name="slotName">The slot name. Must be defined on the intent.</param>
+    /// <param name="samples">The locale-specific slot sample utterances.</param>
+    /// <returns>The current <see cref="LocaleOverrideBuilder"/>.</returns>
+    public LocaleOverrideBuilder WithSlotSamples(string intentName, string slotName, params string[] samples)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(intentName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(slotName);
+        ArgumentNullException.ThrowIfNull(samples);
+
+        if (!_schemaIntents.TryGetValue(intentName, out var intentBuilder))
+            throw new InvalidOperationException($"Intent '{intentName}' is not defined in the interaction model schema.");
+
+        if (!intentBuilder.SlotNames.Contains(slotName))
+            throw new InvalidOperationException($"Slot '{slotName}' is not defined on intent '{intentName}'.");
+
+        if (!_slotSamples.TryGetValue(intentName, out var slots))
+        {
+            slots = [];
+            _slotSamples[intentName] = slots;
+        }
+
+        slots[slotName] = samples;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures the values for the specified slot type in this locale.
+    /// Replaces any previously set configuration for this slot type in this locale.
+    /// </summary>
+    /// <param name="slotTypeName">The slot type name. Must be defined in the schema.</param>
+    /// <param name="configure">The configuration action for the slot type values.</param>
+    /// <returns>The current <see cref="LocaleOverrideBuilder"/>.</returns>
+    public LocaleOverrideBuilder WithSlotValues(string slotTypeName, Action<SlotTypeBuilder> configure)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(slotTypeName);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        if (!_schemaSlotTypes.ContainsKey(slotTypeName))
+            throw new InvalidOperationException($"Slot type '{slotTypeName}' is not defined in the interaction model schema.");
+
+        _slotValueConfigs[slotTypeName] = configure;
+        return this;
+    }
+
+    internal string? InvocationName => _invocationName;
+
+    internal IReadOnlyList<string>? GetIntentSamples(string intentName) =>
+        _intentSamples.TryGetValue(intentName, out var samples) ? samples : null;
+
+    internal IReadOnlyList<string>? GetSlotSamples(string intentName, string slotName) =>
+        _slotSamples.TryGetValue(intentName, out var slots) && slots.TryGetValue(slotName, out var samples)
+            ? samples
+            : null;
+
+    internal Action<SlotTypeBuilder>? GetSlotTypeConfig(string slotTypeName) =>
+        _slotValueConfigs.TryGetValue(slotTypeName, out var config) ? config : null;
+}

--- a/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/LocaleOverrideBuilder.cs
+++ b/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/LocaleOverrideBuilder.cs
@@ -49,7 +49,10 @@ public sealed class LocaleOverrideBuilder
         if (!_schemaIntents.ContainsKey(intentName))
             throw new InvalidOperationException($"Intent '{intentName}' is not defined in the interaction model schema.");
 
-        _intentSamples[intentName] = samples;
+        foreach (var sample in samples)
+            ArgumentException.ThrowIfNullOrWhiteSpace(sample, nameof(samples));
+
+        _intentSamples[intentName] = [..samples];
         return this;
     }
 
@@ -73,13 +76,16 @@ public sealed class LocaleOverrideBuilder
         if (!intentBuilder.SlotNames.Contains(slotName))
             throw new InvalidOperationException($"Slot '{slotName}' is not defined on intent '{intentName}'.");
 
+        foreach (var sample in samples)
+            ArgumentException.ThrowIfNullOrWhiteSpace(sample, nameof(samples));
+
         if (!_slotSamples.TryGetValue(intentName, out var slots))
         {
             slots = [];
             _slotSamples[intentName] = slots;
         }
 
-        slots[slotName] = samples;
+        slots[slotName] = [..samples];
         return this;
     }
 

--- a/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/MultiLocaleInteractionModelBuilder.cs
+++ b/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/MultiLocaleInteractionModelBuilder.cs
@@ -1,0 +1,240 @@
+using System.Collections.Immutable;
+using AlexaVoxCraft.Smapi.Models.InteractionModel;
+
+namespace AlexaVoxCraft.Smapi.Builders.InteractionModel;
+
+/// <summary>
+/// Fluent builder for constructing Alexa interaction models across multiple locales.
+/// Shared schema elements (intent names, slot definitions, slot type names) are defined once.
+/// Locale-specific text (invocation name, sample utterances, slot values) is defined per locale,
+/// with unoverridden values falling back to the default locale.
+/// </summary>
+public sealed class MultiLocaleInteractionModelBuilder
+{
+    private string? _version;
+    private string? _description;
+
+    private readonly Dictionary<string, IntentBuilder> _intents = [];
+    private readonly Dictionary<string, SlotTypeBuilder> _slotTypes = [];
+    private NameFreeInteractionBuilder? _nameFreeInteractionBuilder;
+
+    private string? _defaultLocale;
+    private LocaleOverrideBuilder? _defaultOverrides;
+    private readonly Dictionary<string, LocaleOverrideBuilder> _locales = [];
+
+    private MultiLocaleInteractionModelBuilder()
+    {
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="MultiLocaleInteractionModelBuilder"/> instance.
+    /// </summary>
+    public static MultiLocaleInteractionModelBuilder Create() => new();
+
+    /// <summary>
+    /// Sets the interaction model version.
+    /// </summary>
+    /// <param name="version">The interaction model version string.</param>
+    /// <returns>The current <see cref="MultiLocaleInteractionModelBuilder"/>.</returns>
+    public MultiLocaleInteractionModelBuilder WithVersion(string version)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(version);
+        _version = version;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the interaction model description.
+    /// </summary>
+    /// <param name="description">The description for this interaction model version.</param>
+    /// <returns>The current <see cref="MultiLocaleInteractionModelBuilder"/>.</returns>
+    public MultiLocaleInteractionModelBuilder WithDescription(string description)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(description);
+        _description = description;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds or configures an intent in the shared schema.
+    /// Sample utterances are not set here — provide them per locale via <see cref="WithDefaultLocale"/> and <see cref="ForLocale"/>.
+    /// </summary>
+    /// <param name="name">The intent name.</param>
+    /// <param name="configure">Optional structural configuration (slots only — samples are ignored at the schema level).</param>
+    /// <returns>The current <see cref="MultiLocaleInteractionModelBuilder"/>.</returns>
+    public MultiLocaleInteractionModelBuilder AddIntent(string name, Action<IntentBuilder>? configure = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        if (!_intents.TryGetValue(name, out var builder))
+        {
+            builder = new IntentBuilder(name);
+            _intents[name] = builder;
+        }
+
+        configure?.Invoke(builder);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds or configures a custom slot type in the shared schema.
+    /// Slot values are locale-specific and should be set via <see cref="LocaleOverrideBuilder.WithSlotValues"/>.
+    /// </summary>
+    /// <param name="name">The slot type name.</param>
+    /// <param name="configure">Optional configuration action.</param>
+    /// <returns>The current <see cref="MultiLocaleInteractionModelBuilder"/>.</returns>
+    public MultiLocaleInteractionModelBuilder AddSlotType(string name, Action<SlotTypeBuilder>? configure = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        if (!_slotTypes.TryGetValue(name, out var builder))
+        {
+            builder = new SlotTypeBuilder(name);
+            _slotTypes[name] = builder;
+        }
+
+        configure?.Invoke(builder);
+        return this;
+    }
+
+    /// <summary>
+    /// Configures name-free interaction for the skill. Applied to all locales.
+    /// </summary>
+    /// <param name="configure">The configuration action.</param>
+    /// <returns>The current <see cref="MultiLocaleInteractionModelBuilder"/>.</returns>
+    public MultiLocaleInteractionModelBuilder WithNameFreeInteraction(
+        Action<NameFreeInteractionBuilder>? configure = null)
+    {
+        _nameFreeInteractionBuilder ??= new NameFreeInteractionBuilder();
+        configure?.Invoke(_nameFreeInteractionBuilder);
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the default locale and its text content. The default locale is included in <see cref="BuildAll"/> output
+    /// and provides fallback values for all other locales registered via <see cref="ForLocale"/>.
+    /// </summary>
+    /// <param name="locale">The locale code (e.g., "en-US").</param>
+    /// <param name="configure">The configuration action for the default locale's text content.</param>
+    /// <returns>The current <see cref="MultiLocaleInteractionModelBuilder"/>.</returns>
+    public MultiLocaleInteractionModelBuilder WithDefaultLocale(string locale, Action<LocaleOverrideBuilder> configure)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(locale);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        _defaultLocale = locale;
+        _defaultOverrides ??= new LocaleOverrideBuilder(_intents, _slotTypes);
+        configure(_defaultOverrides);
+        return this;
+    }
+
+    /// <summary>
+    /// Registers an additional locale. Any text not overridden here falls back to the default locale.
+    /// Calling this method multiple times for the same locale merges into the same override builder.
+    /// </summary>
+    /// <param name="locale">The locale code (e.g., "en-GB").</param>
+    /// <param name="configure">Optional configuration action. Omit to inherit everything from the default locale.</param>
+    /// <returns>The current <see cref="MultiLocaleInteractionModelBuilder"/>.</returns>
+    public MultiLocaleInteractionModelBuilder ForLocale(string locale, Action<LocaleOverrideBuilder>? configure = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(locale);
+
+        if (locale == _defaultLocale)
+        {
+            _defaultOverrides ??= new LocaleOverrideBuilder(_intents, _slotTypes);
+            configure?.Invoke(_defaultOverrides);
+            return this;
+        }
+
+        if (!_locales.TryGetValue(locale, out var builder))
+        {
+            builder = new LocaleOverrideBuilder(_intents, _slotTypes);
+            _locales[locale] = builder;
+        }
+
+        configure?.Invoke(builder);
+        return this;
+    }
+
+    /// <summary>
+    /// Builds an interaction model definition for each registered locale, applying default locale fallbacks
+    /// for any text not explicitly overridden.
+    /// </summary>
+    /// <returns>A list of <see cref="LocalizedInteractionModel"/> instances, default locale first.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if no default locale has been set.</exception>
+    public IReadOnlyList<LocalizedInteractionModel> BuildAll()
+    {
+        if (_defaultLocale is null || _defaultOverrides is null)
+            throw new InvalidOperationException("A default locale must be specified using WithDefaultLocale.");
+
+        if (string.IsNullOrWhiteSpace(_version))
+            throw new InvalidOperationException("Interaction model version must be specified.");
+
+        if (string.IsNullOrWhiteSpace(_description))
+            throw new InvalidOperationException("Interaction model description must be specified.");
+
+        if (string.IsNullOrWhiteSpace(_defaultOverrides.InvocationName))
+            throw new InvalidOperationException("Invocation name must be specified in the default locale.");
+
+        var result = new List<LocalizedInteractionModel>
+        {
+            new(_defaultLocale, BuildDefinitionForLocale(_defaultOverrides))
+        };
+
+        foreach (var (locale, overrides) in _locales)
+        {
+            result.Add(new(locale, BuildDefinitionForLocale(overrides)));
+        }
+
+        return result.AsReadOnly();
+    }
+
+    private InteractionModelDefinition BuildDefinitionForLocale(LocaleOverrideBuilder overrides)
+    {
+        var invocationName = overrides.InvocationName ?? _defaultOverrides!.InvocationName!;
+
+        var intents = _intents.Values.Select(intentBuilder =>
+        {
+            var intentSamples = overrides.GetIntentSamples(intentBuilder.Name)
+                ?? _defaultOverrides!.GetIntentSamples(intentBuilder.Name)
+                ?? [];
+
+            var slotSampleOverrides = intentBuilder.SlotNames.ToDictionary(
+                slotName => slotName,
+                slotName => (IReadOnlyList<string>?)(overrides.GetSlotSamples(intentBuilder.Name, slotName)
+                    ?? _defaultOverrides!.GetSlotSamples(intentBuilder.Name, slotName)));
+
+            return intentBuilder.BuildWithSamples(intentSamples, slotSampleOverrides);
+        }).ToImmutableArray();
+
+        var slotTypes = _slotTypes.Select(kvp =>
+        {
+            var configAction = overrides.GetSlotTypeConfig(kvp.Key)
+                ?? _defaultOverrides!.GetSlotTypeConfig(kvp.Key);
+
+            var builder = new SlotTypeBuilder(kvp.Key);
+            configAction?.Invoke(builder);
+            return builder.Build();
+        }).ToImmutableArray();
+
+        var languageModel = new LanguageModel
+        {
+            InvocationName = invocationName,
+            Intents = intents,
+            Types = slotTypes
+        };
+
+        var body = new InteractionModelBody
+        {
+            LanguageModel = languageModel,
+            NameFreeInteraction = _nameFreeInteractionBuilder?.Build()
+        };
+
+        return new InteractionModelDefinition
+        {
+            InteractionModel = body,
+            Version = _version!,
+            Description = _description!
+        };
+    }
+}

--- a/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/MultiLocaleInteractionModelBuilder.cs
+++ b/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/MultiLocaleInteractionModelBuilder.cs
@@ -57,10 +57,11 @@ public sealed class MultiLocaleInteractionModelBuilder
 
     /// <summary>
     /// Adds or configures an intent in the shared schema.
-    /// Sample utterances are not set here — provide them per locale via <see cref="WithDefaultLocale"/> and <see cref="ForLocale"/>.
+    /// Samples set here act as a global fallback used when neither the locale nor the default locale provides samples for this intent.
+    /// Prefer setting samples via <see cref="WithDefaultLocale"/> and <see cref="ForLocale"/> for locale-specific control.
     /// </summary>
     /// <param name="name">The intent name.</param>
-    /// <param name="configure">Optional structural configuration (slots only — samples are ignored at the schema level).</param>
+    /// <param name="configure">Optional configuration action for slots and schema-level fallback samples.</param>
     /// <returns>The current <see cref="MultiLocaleInteractionModelBuilder"/>.</returns>
     public MultiLocaleInteractionModelBuilder AddIntent(string name, Action<IntentBuilder>? configure = null)
     {
@@ -205,7 +206,7 @@ public sealed class MultiLocaleInteractionModelBuilder
         {
             var intentSamples = overrides.GetIntentSamples(intentBuilder.Name)
                 ?? _defaultOverrides!.GetIntentSamples(intentBuilder.Name)
-                ?? [];
+                ?? intentBuilder.Samples;
 
             var slotSampleOverrides = intentBuilder.SlotNames.ToDictionary(
                 slotName => slotName,

--- a/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/MultiLocaleInteractionModelBuilder.cs
+++ b/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/MultiLocaleInteractionModelBuilder.cs
@@ -77,23 +77,18 @@ public sealed class MultiLocaleInteractionModelBuilder
     }
 
     /// <summary>
-    /// Adds or configures a custom slot type in the shared schema.
-    /// Slot values are locale-specific and should be set via <see cref="LocaleOverrideBuilder.WithSlotValues"/>.
+    /// Registers a custom slot type in the shared schema.
+    /// Slot values are locale-specific; provide them per locale via <see cref="LocaleOverrideBuilder.WithSlotValues"/>.
     /// </summary>
     /// <param name="name">The slot type name.</param>
-    /// <param name="configure">Optional configuration action.</param>
     /// <returns>The current <see cref="MultiLocaleInteractionModelBuilder"/>.</returns>
-    public MultiLocaleInteractionModelBuilder AddSlotType(string name, Action<SlotTypeBuilder>? configure = null)
+    public MultiLocaleInteractionModelBuilder AddSlotType(string name)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
-        if (!_slotTypes.TryGetValue(name, out var builder))
-        {
-            builder = new SlotTypeBuilder(name);
-            _slotTypes[name] = builder;
-        }
+        if (!_slotTypes.ContainsKey(name))
+            _slotTypes[name] = new SlotTypeBuilder(name);
 
-        configure?.Invoke(builder);
         return this;
     }
 
@@ -183,6 +178,9 @@ public sealed class MultiLocaleInteractionModelBuilder
 
         foreach (var (locale, overrides) in _locales)
         {
+            if (locale == _defaultLocale)
+                continue;
+
             result.Add(new(locale, BuildDefinitionForLocale(overrides)));
         }
 

--- a/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/MultiLocaleInteractionModelBuilder.cs
+++ b/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/MultiLocaleInteractionModelBuilder.cs
@@ -117,7 +117,17 @@ public sealed class MultiLocaleInteractionModelBuilder
         ArgumentException.ThrowIfNullOrWhiteSpace(locale);
         ArgumentNullException.ThrowIfNull(configure);
 
+        if (_defaultLocale is not null && _defaultLocale != locale)
+            throw new InvalidOperationException($"Default locale is already set to '{_defaultLocale}'.");
+
         _defaultLocale = locale;
+
+        if (_defaultOverrides is null && _locales.TryGetValue(locale, out var promoted))
+        {
+            _defaultOverrides = promoted;
+            _locales.Remove(locale);
+        }
+
         _defaultOverrides ??= new LocaleOverrideBuilder(_intents, _slotTypes);
         configure(_defaultOverrides);
         return this;

--- a/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/SlotBuilder.cs
+++ b/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/SlotBuilder.cs
@@ -91,12 +91,15 @@ public sealed class SlotBuilder
     internal string Name => _name;
 
     internal IntentSlot BuildWithSamples(IReadOnlyList<string>? samples)
-        => new()
+    {
+        var effectiveSamples = samples ?? (IReadOnlyList<string>)_samples;
+        return new()
         {
             Name = _name,
             Type = _type,
             IsRequired = _isRequired,
-            Samples = samples?.Count > 0 ? [.. samples] : null
+            Samples = effectiveSamples.Count > 0 ? [.. effectiveSamples] : null
         };
+    }
 }
 

--- a/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/SlotBuilder.cs
+++ b/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/SlotBuilder.cs
@@ -87,4 +87,15 @@ public sealed class SlotBuilder
             IsRequired = _isRequired,
             Samples = _samples.Count > 0 ? [.. _samples] : null
         };
+
+    internal string Name => _name;
+
+    internal IntentSlot BuildWithSamples(IReadOnlyList<string>? samples)
+        => new()
+        {
+            Name = _name,
+            Type = _type,
+            IsRequired = _isRequired,
+            Samples = samples?.Count > 0 ? [.. samples] : null
+        };
 }

--- a/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/SlotBuilder.cs
+++ b/src/AlexaVoxCraft.Smapi/Builders/InteractionModel/SlotBuilder.cs
@@ -99,3 +99,4 @@ public sealed class SlotBuilder
             Samples = samples?.Count > 0 ? [.. samples] : null
         };
 }
+

--- a/src/AlexaVoxCraft.Smapi/Clients/AlexaInteractionModelClient.cs
+++ b/src/AlexaVoxCraft.Smapi/Clients/AlexaInteractionModelClient.cs
@@ -39,12 +39,16 @@ public sealed class AlexaInteractionModelClient : BaseClient, IAlexaInteractionM
 
     /// <inheritdoc />
     public Task UpdateAsync(string skillId, string stage, LocalizedInteractionModel model, CancellationToken ct)
-        => UpdateAsync(skillId, stage, model.Locale, model.Definition, ct);
+    {
+        ArgumentNullException.ThrowIfNull(model);
+        return UpdateAsync(skillId, stage, model.Locale, model.Definition, ct);
+    }
 
     /// <inheritdoc />
     public async Task UpdateAllAsync(string skillId, string stage, IEnumerable<LocalizedInteractionModel> models,
         CancellationToken ct)
     {
+        ArgumentNullException.ThrowIfNull(models);
         var errors = new List<Exception>();
         foreach (var model in models)
         {

--- a/src/AlexaVoxCraft.Smapi/Clients/AlexaInteractionModelClient.cs
+++ b/src/AlexaVoxCraft.Smapi/Clients/AlexaInteractionModelClient.cs
@@ -36,4 +36,34 @@ public sealed class AlexaInteractionModelClient : BaseClient, IAlexaInteractionM
                 model, null, ct)
             .ConfigureAwait(false);
     }
+
+    /// <inheritdoc />
+    public Task UpdateAsync(string skillId, string stage, LocalizedInteractionModel model, CancellationToken ct)
+        => UpdateAsync(skillId, stage, model.Locale, model.Definition, ct);
+
+    /// <inheritdoc />
+    public async Task UpdateAllAsync(string skillId, string stage, IEnumerable<LocalizedInteractionModel> models,
+        CancellationToken ct)
+    {
+        var errors = new List<Exception>();
+        foreach (var model in models)
+        {
+            ct.ThrowIfCancellationRequested();
+            try
+            {
+                await UpdateAsync(skillId, stage, model, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                errors.Add(ex);
+            }
+        }
+
+        if (errors.Count > 0)
+            throw new AggregateException($"Failed to update {errors.Count} locale(s).", errors);
+    }
 }

--- a/src/AlexaVoxCraft.Smapi/Clients/IAlexaInteractionModelClient.cs
+++ b/src/AlexaVoxCraft.Smapi/Clients/IAlexaInteractionModelClient.cs
@@ -27,4 +27,25 @@ public interface IAlexaInteractionModelClient
     /// <param name="ct">The cancellation token.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     Task UpdateAsync(string skillId, string stage, string locale, InteractionModelDefinition model, CancellationToken ct);
+
+    /// <summary>
+    /// Updates the interaction model for a specific skill and stage using a <see cref="LocalizedInteractionModel"/>.
+    /// The locale is taken from the <see cref="LocalizedInteractionModel.Locale"/> property.
+    /// </summary>
+    /// <param name="skillId">The Alexa skill identifier.</param>
+    /// <param name="stage">The skill stage (e.g., "development", "live").</param>
+    /// <param name="model">The localized interaction model to upload.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task UpdateAsync(string skillId, string stage, LocalizedInteractionModel model, CancellationToken ct);
+
+    /// <summary>
+    /// Updates the interaction model for multiple locales sequentially.
+    /// </summary>
+    /// <param name="skillId">The Alexa skill identifier.</param>
+    /// <param name="stage">The skill stage (e.g., "development", "live").</param>
+    /// <param name="models">The localized interaction models to upload.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task UpdateAllAsync(string skillId, string stage, IEnumerable<LocalizedInteractionModel> models, CancellationToken ct);
 }

--- a/src/AlexaVoxCraft.Smapi/Models/InteractionModel/LocalizedInteractionModel.cs
+++ b/src/AlexaVoxCraft.Smapi/Models/InteractionModel/LocalizedInteractionModel.cs
@@ -1,0 +1,8 @@
+namespace AlexaVoxCraft.Smapi.Models.InteractionModel;
+
+/// <summary>
+/// Pairs a locale code with its <see cref="InteractionModelDefinition"/>.
+/// </summary>
+/// <param name="Locale">The locale code (e.g., "en-US", "en-GB").</param>
+/// <param name="Definition">The interaction model definition for this locale.</param>
+public sealed record LocalizedInteractionModel(string Locale, InteractionModelDefinition Definition);

--- a/test/AlexaVoxCraft.Smapi.Tests/Builders/InteractionModel/IntentBuilderTests.cs
+++ b/test/AlexaVoxCraft.Smapi.Tests/Builders/InteractionModel/IntentBuilderTests.cs
@@ -1,0 +1,93 @@
+using AlexaVoxCraft.Smapi.Builders.InteractionModel;
+
+namespace AlexaVoxCraft.Smapi.Tests.Builders.InteractionModel;
+
+public sealed class IntentBuilderTests
+{
+    [Fact]
+    public async Task Build_WithNoSamplesOrSlots_ReturnsIntentWithEmptyCollections()
+    {
+        var intent = new IntentBuilder("OrderIntent")
+            .Build();
+
+        await Verify(intent).DisableDiff();
+    }
+
+    [Fact]
+    public async Task Build_WithSingleSample_IncludesSampleInResult()
+    {
+        var intent = new IntentBuilder("OrderIntent")
+            .WithSample("order {drink}")
+            .Build();
+
+        await Verify(intent).DisableDiff();
+    }
+
+    [Fact]
+    public async Task Build_WithMultipleSamplesViaWithSample_IncludesAllSamples()
+    {
+        var intent = new IntentBuilder("OrderIntent")
+            .WithSample("order {drink}")
+            .WithSample("get {drink}")
+            .WithSample("I'd like {drink}")
+            .Build();
+
+        await Verify(intent).DisableDiff();
+    }
+
+    [Fact]
+    public async Task Build_WithMultipleSamplesViaWithSamples_IncludesAllSamples()
+    {
+        var intent = new IntentBuilder("OrderIntent")
+            .WithSamples("order {drink}", "get {drink}", "I'd like {drink}")
+            .Build();
+
+        await Verify(intent).DisableDiff();
+    }
+
+    [Fact]
+    public async Task Build_WithSingleSlot_IncludesSlotInResult()
+    {
+        var intent = new IntentBuilder("OrderIntent")
+            .WithSample("order {drink}")
+            .WithSlot("drink", "DrinkType")
+            .Build();
+
+        await Verify(intent).DisableDiff();
+    }
+
+    [Fact]
+    public async Task Build_WithMultipleSlots_IncludesAllSlots()
+    {
+        var intent = new IntentBuilder("OrderIntent")
+            .WithSample("order {drink} in {size}")
+            .WithSlot("drink", "DrinkType")
+            .WithSlot("size", "SizeType")
+            .Build();
+
+        await Verify(intent).DisableDiff();
+    }
+
+    [Fact]
+    public async Task Build_WithConfiguredSlot_IncludesSlotConfiguration()
+    {
+        var intent = new IntentBuilder("OrderIntent")
+            .WithSample("order {drink}")
+            .WithSlot("drink", "DrinkType", slot => slot.Required().WithSample("{drink}"))
+            .Build();
+
+        await Verify(intent).DisableDiff();
+    }
+
+    [Fact]
+    public void WithSlot_WithDuplicateSlotName_ThrowsInvalidOperationException()
+    {
+        var builder = new IntentBuilder("OrderIntent")
+            .WithSlot("drink", "DrinkType");
+
+        var act = () => builder.WithSlot("drink", "AnotherType");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("Slot 'drink' has already been added to intent 'OrderIntent'.");
+    }
+}

--- a/test/AlexaVoxCraft.Smapi.Tests/Builders/InteractionModel/IntentBuilderTests.cs
+++ b/test/AlexaVoxCraft.Smapi.Tests/Builders/InteractionModel/IntentBuilderTests.cs
@@ -90,4 +90,17 @@ public sealed class IntentBuilderTests
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("Slot 'drink' has already been added to intent 'OrderIntent'.");
     }
+
+    [Fact]
+    public void WithSlot_WhenConfigureThrows_SlotNameIsNotRetained()
+    {
+        var builder = new IntentBuilder("OrderIntent");
+
+        var act = () => builder.WithSlot("drink", "DrinkType", _ => throw new InvalidOperationException("configure failed"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("configure failed");
+
+        var intent = builder.WithSlot("drink", "DrinkType").Build();
+        intent.Slots.Should().HaveCount(1);
+    }
 }

--- a/test/AlexaVoxCraft.Smapi.Tests/Builders/InteractionModel/InteractionModelBuilderTests.cs
+++ b/test/AlexaVoxCraft.Smapi.Tests/Builders/InteractionModel/InteractionModelBuilderTests.cs
@@ -1,5 +1,6 @@
 using AlexaVoxCraft.Model.Request.Type;
 using AlexaVoxCraft.Smapi.Builders.InteractionModel;
+using AlexaVoxCraft.Smapi.Models.InteractionModel;
 
 namespace AlexaVoxCraft.Smapi.Tests.Builders.InteractionModel;
 
@@ -33,6 +34,38 @@ public class InteractionModelBuilderTests
                     .WithValue("attack", v => v.WithSynonyms("strike", "hit")))
             .ToJson();
         await Verify(json).DisableDiff();
+    }
+
+    [Fact]
+    public void BuildLocalized_WithLocale_ReturnsLocalizedModel()
+    {
+        var result = InteractionModelBuilder.Create()
+            .WithLocale("en-US")
+            .WithInvocationName("my skill")
+            .WithVersion("1")
+            .WithDescription("Test")
+            .AddIntent(BuiltInIntent.Cancel)
+            .BuildLocalized();
+
+        result.Should().BeOfType<LocalizedInteractionModel>();
+        result.Locale.Should().Be("en-US");
+        result.Definition.Should().NotBeNull();
+        result.Definition.InteractionModel.LanguageModel.InvocationName.Should().Be("my skill");
+    }
+
+    [Fact]
+    public void BuildLocalized_WithoutLocale_ThrowsInvalidOperationException()
+    {
+        var builder = InteractionModelBuilder.Create()
+            .WithInvocationName("my skill")
+            .WithVersion("1")
+            .WithDescription("Test")
+            .AddIntent(BuiltInIntent.Cancel);
+
+        var act = () => builder.BuildLocalized();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("A locale must be specified using WithLocale.");
     }
 
     [Fact]

--- a/test/AlexaVoxCraft.Smapi.Tests/Builders/InteractionModel/InteractionModelBuilderTests.cs
+++ b/test/AlexaVoxCraft.Smapi.Tests/Builders/InteractionModel/InteractionModelBuilderTests.cs
@@ -4,7 +4,7 @@ using AlexaVoxCraft.Smapi.Models.InteractionModel;
 
 namespace AlexaVoxCraft.Smapi.Tests.Builders.InteractionModel;
 
-public class InteractionModelBuilderTests
+public sealed class InteractionModelBuilderTests
 {
     [Fact]
     public async Task ToJson_CreatesCorrectJson()

--- a/test/AlexaVoxCraft.Smapi.Tests/Builders/InteractionModel/MultiLocaleInteractionModelBuilderTests.cs
+++ b/test/AlexaVoxCraft.Smapi.Tests/Builders/InteractionModel/MultiLocaleInteractionModelBuilderTests.cs
@@ -1,0 +1,216 @@
+using AlexaVoxCraft.Model.Request.Type;
+using AlexaVoxCraft.Smapi.Builders.InteractionModel;
+
+namespace AlexaVoxCraft.Smapi.Tests.Builders.InteractionModel;
+
+public class MultiLocaleInteractionModelBuilderTests
+{
+    [Fact]
+    public async Task BuildAll_WithSingleDefaultLocale_ReturnsOneModel()
+    {
+        var models = MultiLocaleInteractionModelBuilder.Create()
+            .WithVersion("1")
+            .WithDescription("Single locale skill")
+            .AddIntent("HelloIntent", i => i.WithSamples("say hello", "hello"))
+            .AddIntent(BuiltInIntent.Cancel)
+            .WithDefaultLocale("en-US", locale => locale
+                .WithInvocationName("my skill")
+                .WithIntentSamples("HelloIntent", "say hello", "hello"))
+            .BuildAll();
+
+        await Verify(models).DisableDiff();
+    }
+
+    [Fact]
+    public async Task BuildAll_WithMultipleLocales_ReturnsAllLocales()
+    {
+        var models = MultiLocaleInteractionModelBuilder.Create()
+            .WithVersion("1")
+            .WithDescription("Multi-locale skill")
+            .AddIntent("OrderIntent", i => i.WithSlot("drink", "DrinkType"))
+            .AddIntent(BuiltInIntent.Cancel)
+            .AddIntent(BuiltInIntent.Stop)
+            .AddSlotType("DrinkType")
+            .WithDefaultLocale("en-US", locale => locale
+                .WithInvocationName("my skill")
+                .WithIntentSamples("OrderIntent", "order {drink}", "get {drink}")
+                .WithSlotValues("DrinkType", v => v.WithValue("coffee").WithValue("tea")))
+            .ForLocale("en-CA")
+            .ForLocale("en-GB", locale => locale
+                .WithIntentSamples("OrderIntent", "order {drink}", "I'd like {drink}"))
+            .BuildAll();
+
+        await Verify(models).DisableDiff();
+    }
+
+    [Fact]
+    public async Task BuildAll_WithLocaleOverridingInvocationName_UsesOverrideForThatLocale()
+    {
+        var models = MultiLocaleInteractionModelBuilder.Create()
+            .WithVersion("1")
+            .WithDescription("Invocation name override test")
+            .AddIntent(BuiltInIntent.Cancel)
+            .WithDefaultLocale("en-US", locale => locale
+                .WithInvocationName("my skill"))
+            .ForLocale("en-GB", locale => locale
+                .WithInvocationName("my british skill"))
+            .ForLocale("en-CA")
+            .BuildAll();
+
+        await Verify(models).DisableDiff();
+    }
+
+    [Fact]
+    public async Task BuildAll_WithIntentSamplesOverride_AppliesOverrideForLocale()
+    {
+        var models = MultiLocaleInteractionModelBuilder.Create()
+            .WithVersion("1")
+            .WithDescription("Intent samples override test")
+            .AddIntent("GreetIntent")
+            .AddIntent(BuiltInIntent.Stop)
+            .WithDefaultLocale("en-US", locale => locale
+                .WithInvocationName("my skill")
+                .WithIntentSamples("GreetIntent", "say hello", "greet me"))
+            .ForLocale("en-GB", locale => locale
+                .WithIntentSamples("GreetIntent", "say hello", "good day"))
+            .ForLocale("en-CA")
+            .BuildAll();
+
+        await Verify(models).DisableDiff();
+    }
+
+    [Fact]
+    public async Task BuildAll_WithSlotSamplesOverride_AppliesOverrideForLocale()
+    {
+        var models = MultiLocaleInteractionModelBuilder.Create()
+            .WithVersion("1")
+            .WithDescription("Slot samples override test")
+            .AddIntent("OrderIntent", i => i.WithSlot("item", "AMAZON.Food"))
+            .WithDefaultLocale("en-US", locale => locale
+                .WithInvocationName("my skill")
+                .WithIntentSamples("OrderIntent", "order {item}")
+                .WithSlotSamples("OrderIntent", "item", "coffee", "sandwich"))
+            .ForLocale("en-GB", locale => locale
+                .WithSlotSamples("OrderIntent", "item", "tea", "biscuit"))
+            .BuildAll();
+
+        await Verify(models).DisableDiff();
+    }
+
+    [Fact]
+    public async Task BuildAll_WithSlotValuesOverride_AppliesOverrideForLocale()
+    {
+        var models = MultiLocaleInteractionModelBuilder.Create()
+            .WithVersion("1")
+            .WithDescription("Slot values override test")
+            .AddIntent("OrderIntent", i => i.WithSlot("drink", "DrinkType"))
+            .AddSlotType("DrinkType")
+            .WithDefaultLocale("en-US", locale => locale
+                .WithInvocationName("my skill")
+                .WithIntentSamples("OrderIntent", "order {drink}")
+                .WithSlotValues("DrinkType", v => v.WithValue("soda").WithValue("coffee")))
+            .ForLocale("en-GB", locale => locale
+                .WithSlotValues("DrinkType", v => v.WithValue("fizzy drink").WithValue("coffee")))
+            .BuildAll();
+
+        await Verify(models).DisableDiff();
+    }
+
+    [Fact]
+    public async Task BuildAll_WithForLocaleAndNoLambda_InheritsAllFromDefault()
+    {
+        var models = MultiLocaleInteractionModelBuilder.Create()
+            .WithVersion("1")
+            .WithDescription("Inherit all from default")
+            .AddIntent("HelloIntent")
+            .WithDefaultLocale("en-US", locale => locale
+                .WithInvocationName("my skill")
+                .WithIntentSamples("HelloIntent", "say hello", "hello there"))
+            .ForLocale("en-CA")
+            .ForLocale("en-AU")
+            .BuildAll();
+
+        await Verify(models).DisableDiff();
+    }
+
+    [Fact]
+    public async Task BuildAll_WithDuplicateForLocale_MergesIntoSameBuilder()
+    {
+        var models = MultiLocaleInteractionModelBuilder.Create()
+            .WithVersion("1")
+            .WithDescription("Duplicate locale merge test")
+            .AddIntent("FooIntent")
+            .AddIntent("BarIntent")
+            .WithDefaultLocale("en-US", locale => locale
+                .WithInvocationName("my skill")
+                .WithIntentSamples("FooIntent", "do foo")
+                .WithIntentSamples("BarIntent", "do bar"))
+            .ForLocale("en-GB", locale => locale
+                .WithIntentSamples("FooIntent", "do foo differently"))
+            .ForLocale("en-GB", locale => locale
+                .WithInvocationName("my british skill"))
+            .BuildAll();
+
+        await Verify(models).DisableDiff();
+    }
+
+    [Fact]
+    public void BuildAll_WithNoDefaultLocale_ThrowsInvalidOperationException()
+    {
+        var builder = MultiLocaleInteractionModelBuilder.Create()
+            .WithVersion("1")
+            .WithDescription("Missing default locale")
+            .AddIntent(BuiltInIntent.Cancel);
+
+        var act = () => builder.BuildAll();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("A default locale must be specified using WithDefaultLocale.");
+    }
+
+    [Fact]
+    public void WithIntentSamples_ForUnknownIntent_ThrowsInvalidOperationException()
+    {
+        var act = () => MultiLocaleInteractionModelBuilder.Create()
+            .WithVersion("1")
+            .WithDescription("Unknown intent test")
+            .AddIntent("KnownIntent")
+            .WithDefaultLocale("en-US", locale => locale
+                .WithInvocationName("my skill")
+                .WithIntentSamples("UnknownIntent", "some sample"));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("Intent 'UnknownIntent' is not defined in the interaction model schema.");
+    }
+
+    [Fact]
+    public void WithSlotSamples_ForUnknownSlot_ThrowsInvalidOperationException()
+    {
+        var act = () => MultiLocaleInteractionModelBuilder.Create()
+            .WithVersion("1")
+            .WithDescription("Unknown slot test")
+            .AddIntent("OrderIntent", i => i.WithSlot("drink", "DrinkType"))
+            .WithDefaultLocale("en-US", locale => locale
+                .WithInvocationName("my skill")
+                .WithIntentSamples("OrderIntent", "order {drink}")
+                .WithSlotSamples("OrderIntent", "unknownSlot", "some value"));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("Slot 'unknownSlot' is not defined on intent 'OrderIntent'.");
+    }
+
+    [Fact]
+    public void WithSlotValues_ForUnknownSlotType_ThrowsInvalidOperationException()
+    {
+        var act = () => MultiLocaleInteractionModelBuilder.Create()
+            .WithVersion("1")
+            .WithDescription("Unknown slot type test")
+            .AddSlotType("KnownType")
+            .WithDefaultLocale("en-US", locale => locale
+                .WithInvocationName("my skill")
+                .WithSlotValues("UnknownType", v => v.WithValue("foo")));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("Slot type 'UnknownType' is not defined in the interaction model schema.");
+    }
+}

--- a/test/AlexaVoxCraft.Smapi.Tests/Builders/InteractionModel/MultiLocaleInteractionModelBuilderTests.cs
+++ b/test/AlexaVoxCraft.Smapi.Tests/Builders/InteractionModel/MultiLocaleInteractionModelBuilderTests.cs
@@ -213,4 +213,34 @@ public sealed class MultiLocaleInteractionModelBuilderTests
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("Slot type 'UnknownType' is not defined in the interaction model schema.");
     }
+
+    [Fact]
+    public void WithDefaultLocale_CalledTwiceWithDifferentLocale_ThrowsInvalidOperationException()
+    {
+        var act = () => MultiLocaleInteractionModelBuilder.Create()
+            .WithVersion("1")
+            .WithDescription("Double default locale test")
+            .AddIntent(BuiltInIntent.Cancel)
+            .WithDefaultLocale("en-US", locale => locale.WithInvocationName("my skill"))
+            .WithDefaultLocale("en-GB", locale => locale.WithInvocationName("my british skill"));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("Default locale is already set to 'en-US'.");
+    }
+
+    [Fact]
+    public void WithDefaultLocale_WhenForLocaleCalledFirstForSameLocale_PreservesOverrides()
+    {
+        var models = MultiLocaleInteractionModelBuilder.Create()
+            .WithVersion("1")
+            .WithDescription("ForLocale before WithDefaultLocale test")
+            .AddIntent(BuiltInIntent.Cancel)
+            .ForLocale("en-US", locale => locale.WithInvocationName("my skill"))
+            .WithDefaultLocale("en-US", _ => { })
+            .BuildAll();
+
+        models.Should().HaveCount(1);
+        models[0].Locale.Should().Be("en-US");
+        models[0].Definition.InteractionModel.LanguageModel.InvocationName.Should().Be("my skill");
+    }
 }

--- a/test/AlexaVoxCraft.Smapi.Tests/Builders/InteractionModel/MultiLocaleInteractionModelBuilderTests.cs
+++ b/test/AlexaVoxCraft.Smapi.Tests/Builders/InteractionModel/MultiLocaleInteractionModelBuilderTests.cs
@@ -215,6 +215,72 @@ public sealed class MultiLocaleInteractionModelBuilderTests
     }
 
     [Fact]
+    public void BuildAll_WithSchemaLevelIntentSamples_UsedAsFallbackWhenNoLocaleOverride()
+    {
+        var models = MultiLocaleInteractionModelBuilder.Create()
+            .WithVersion("1")
+            .WithDescription("Schema sample fallback test")
+            .AddIntent("GreetIntent", i => i.WithSamples("hello", "hi there"))
+            .WithDefaultLocale("en-US", locale => locale.WithInvocationName("my skill"))
+            .ForLocale("en-CA")
+            .BuildAll();
+
+        var enUs = models.Single(m => m.Locale == "en-US");
+        enUs.Definition.InteractionModel.LanguageModel.Intents
+            .Single(i => i.Name == "GreetIntent").Samples
+            .Should().BeEquivalentTo(["hello", "hi there"]);
+
+        var enCa = models.Single(m => m.Locale == "en-CA");
+        enCa.Definition.InteractionModel.LanguageModel.Intents
+            .Single(i => i.Name == "GreetIntent").Samples
+            .Should().BeEquivalentTo(["hello", "hi there"]);
+    }
+
+    [Fact]
+    public void BuildAll_WithSchemaLevelSlotSamples_UsedAsFallbackWhenNoLocaleOverride()
+    {
+        var models = MultiLocaleInteractionModelBuilder.Create()
+            .WithVersion("1")
+            .WithDescription("Schema slot sample fallback test")
+            .AddIntent("OrderIntent", i => i
+                .WithSamples("order {drink}")
+                .WithSlot("drink", "DrinkType", slot => slot.WithSamples("coffee", "tea")))
+            .WithDefaultLocale("en-US", locale => locale.WithInvocationName("my skill"))
+            .ForLocale("en-CA")
+            .BuildAll();
+
+        var enUs = models.Single(m => m.Locale == "en-US");
+        enUs.Definition.InteractionModel.LanguageModel.Intents
+            .Single(i => i.Name == "OrderIntent").Slots!
+            .Single(s => s.Name == "drink").Samples
+            .Should().BeEquivalentTo(["coffee", "tea"]);
+
+        var enCa = models.Single(m => m.Locale == "en-CA");
+        enCa.Definition.InteractionModel.LanguageModel.Intents
+            .Single(i => i.Name == "OrderIntent").Slots!
+            .Single(s => s.Name == "drink").Samples
+            .Should().BeEquivalentTo(["coffee", "tea"]);
+    }
+
+    [Fact]
+    public void BuildAll_WithLocaleOverride_TakesPrecedenceOverSchemaLevelSamples()
+    {
+        var models = MultiLocaleInteractionModelBuilder.Create()
+            .WithVersion("1")
+            .WithDescription("Override precedence test")
+            .AddIntent("GreetIntent", i => i.WithSamples("hello", "hi there"))
+            .WithDefaultLocale("en-US", locale => locale
+                .WithInvocationName("my skill")
+                .WithIntentSamples("GreetIntent", "good day"))
+            .BuildAll();
+
+        var enUs = models.Single(m => m.Locale == "en-US");
+        enUs.Definition.InteractionModel.LanguageModel.Intents
+            .Single(i => i.Name == "GreetIntent").Samples
+            .Should().BeEquivalentTo(["good day"]);
+    }
+
+    [Fact]
     public void WithDefaultLocale_CalledTwiceWithDifferentLocale_ThrowsInvalidOperationException()
     {
         var act = () => MultiLocaleInteractionModelBuilder.Create()

--- a/test/AlexaVoxCraft.Smapi.Tests/Builders/InteractionModel/MultiLocaleInteractionModelBuilderTests.cs
+++ b/test/AlexaVoxCraft.Smapi.Tests/Builders/InteractionModel/MultiLocaleInteractionModelBuilderTests.cs
@@ -3,7 +3,7 @@ using AlexaVoxCraft.Smapi.Builders.InteractionModel;
 
 namespace AlexaVoxCraft.Smapi.Tests.Builders.InteractionModel;
 
-public class MultiLocaleInteractionModelBuilderTests
+public sealed class MultiLocaleInteractionModelBuilderTests
 {
     [Fact]
     public async Task BuildAll_WithSingleDefaultLocale_ReturnsOneModel()

--- a/test/AlexaVoxCraft.Smapi.Tests/Builders/InteractionModel/SlotBuilderTests.cs
+++ b/test/AlexaVoxCraft.Smapi.Tests/Builders/InteractionModel/SlotBuilderTests.cs
@@ -10,7 +10,7 @@ public sealed class SlotBuilderTests
         var slot = new SlotBuilder("productCategory", "factType")
             .Build();
 
-        await Verify(slot);
+        await Verify(slot).DisableDiff();
     }
 
     [Fact]
@@ -20,7 +20,7 @@ public sealed class SlotBuilderTests
             .WithSample("{productCategory} pack")
             .Build();
 
-        await Verify(slot);
+        await Verify(slot).DisableDiff();
     }
 
     [Fact]
@@ -32,7 +32,7 @@ public sealed class SlotBuilderTests
             .WithSample("Tell me about the {productCategory} pack")
             .Build();
 
-        await Verify(slot);
+        await Verify(slot).DisableDiff();
     }
 
     [Fact]
@@ -46,7 +46,7 @@ public sealed class SlotBuilderTests
                 "Tell me about {productCategory} pack")
             .Build();
 
-        await Verify(slot);
+        await Verify(slot).DisableDiff();
     }
 
     [Fact]
@@ -57,6 +57,6 @@ public sealed class SlotBuilderTests
             .WithSamples("{productCategory} pack", "Tell me about a {productCategory} pack")
             .Build();
 
-        await Verify(slot);
+        await Verify(slot).DisableDiff();
     }
 }

--- a/test/AlexaVoxCraft.Smapi.Tests/Clients/AlexaInteractionModelClientTests.cs
+++ b/test/AlexaVoxCraft.Smapi.Tests/Clients/AlexaInteractionModelClientTests.cs
@@ -167,4 +167,88 @@ public sealed class AlexaInteractionModelClientTests
 
         handler.Received();
     }
+
+    [Theory, SmapiClientAutoData]
+    public async Task UpdateAsync_WithLocalizedModel_CallsCorrectEndpoint(
+        [Frozen] HttpMessageHandler handler,
+        AlexaInteractionModelClient client,
+        string skillId,
+        string stage,
+        string locale,
+        InteractionModelDefinition definition)
+    {
+        var model = new LocalizedInteractionModel(locale, definition);
+        var expectedUri = $"/v1/skills/{skillId}/stages/{stage}/interactionModel/locales/{locale}";
+        handler.ReturnsResponse(HttpStatusCode.NoContent,
+            predicate: req => req.RequestUri?.PathAndQuery == expectedUri && req.Method == HttpMethod.Put);
+
+        await client.UpdateAsync(skillId, stage, model, TestContext.Current.CancellationToken);
+
+        handler.Received();
+    }
+
+    [Theory, SmapiClientAutoData]
+    public async Task UpdateAllAsync_WithMultipleModels_CallsEndpointForEach(
+        [Frozen] HttpMessageHandler handler,
+        AlexaInteractionModelClient client,
+        string skillId,
+        string stage,
+        InteractionModelDefinition definition1,
+        InteractionModelDefinition definition2)
+    {
+        var models = new[]
+        {
+            new LocalizedInteractionModel("en-US", definition1),
+            new LocalizedInteractionModel("en-GB", definition2)
+        };
+        handler.ReturnsResponse(HttpStatusCode.NoContent);
+
+        await client.UpdateAllAsync(skillId, stage, models, TestContext.Current.CancellationToken);
+
+        handler.Received(2);
+    }
+
+    [Theory, SmapiClientAutoData]
+    public async Task UpdateAllAsync_WithEmptyModels_CompletesWithoutCalling(
+        [Frozen] HttpMessageHandler handler,
+        AlexaInteractionModelClient client,
+        string skillId,
+        string stage)
+    {
+        await client.UpdateAllAsync(skillId, stage, [], TestContext.Current.CancellationToken);
+
+        handler.DidNotReceive();
+    }
+
+    [Theory, SmapiClientAutoData]
+    public async Task UpdateAllAsync_WhenSomeLocalesFail_ThrowsAggregateExceptionAfterAttemptingAll(
+        [Frozen] HttpMessageHandler handler,
+        AlexaInteractionModelClient client,
+        string skillId,
+        string stage,
+        InteractionModelDefinition definition1,
+        InteractionModelDefinition definition2,
+        InteractionModelDefinition definition3)
+    {
+        var models = new[]
+        {
+            new LocalizedInteractionModel("en-US", definition1),
+            new LocalizedInteractionModel("en-CA", definition2),
+            new LocalizedInteractionModel("en-GB", definition3)
+        };
+
+        handler.ReturnsResponse(HttpStatusCode.NoContent, predicate: req =>
+            req.RequestUri!.PathAndQuery.EndsWith("/en-US"));
+
+        handler.ReturnsResponse(HttpStatusCode.InternalServerError, predicate: req =>
+            req.RequestUri!.PathAndQuery.EndsWith("/en-CA"));
+
+        handler.ReturnsResponse(HttpStatusCode.InternalServerError, predicate: req =>
+            req.RequestUri!.PathAndQuery.EndsWith("/en-GB"));
+
+        var act = () => client.UpdateAllAsync(skillId, stage, models, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<AggregateException>()
+            .WithMessage("Failed to update 2 locale(s).*");
+    }
 }

--- a/test/AlexaVoxCraft.Smapi.Tests/Clients/AlexaInteractionModelClientTests.cs
+++ b/test/AlexaVoxCraft.Smapi.Tests/Clients/AlexaInteractionModelClientTests.cs
@@ -188,6 +188,18 @@ public sealed class AlexaInteractionModelClientTests
     }
 
     [Theory, SmapiClientAutoData]
+    public async Task UpdateAsync_WithNullLocalizedModel_ThrowsArgumentNullException(
+        AlexaInteractionModelClient client,
+        string skillId,
+        string stage)
+    {
+        var act = () => client.UpdateAsync(skillId, stage, (LocalizedInteractionModel)null!, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<ArgumentNullException>()
+            .WithParameterName("model");
+    }
+
+    [Theory, SmapiClientAutoData]
     public async Task UpdateAllAsync_WithMultipleModels_CallsEndpointForEach(
         [Frozen] HttpMessageHandler handler,
         AlexaInteractionModelClient client,

--- a/test/AlexaVoxCraft.Smapi.Tests/Snapshots/IntentBuilderTests.Build_WithConfiguredSlot_IncludesSlotConfiguration.verified.json
+++ b/test/AlexaVoxCraft.Smapi.Tests/Snapshots/IntentBuilderTests.Build_WithConfiguredSlot_IncludesSlotConfiguration.verified.json
@@ -1,0 +1,16 @@
+﻿{
+  "Name": "OrderIntent",
+  "Samples": [
+    "order {drink}"
+  ],
+  "Slots": [
+    {
+      "Name": "drink",
+      "Type": "DrinkType",
+      "IsRequired": true,
+      "Samples": [
+        "{drink}"
+      ]
+    }
+  ]
+}

--- a/test/AlexaVoxCraft.Smapi.Tests/Snapshots/IntentBuilderTests.Build_WithMultipleSamplesViaWithSample_IncludesAllSamples.verified.json
+++ b/test/AlexaVoxCraft.Smapi.Tests/Snapshots/IntentBuilderTests.Build_WithMultipleSamplesViaWithSample_IncludesAllSamples.verified.json
@@ -1,0 +1,8 @@
+﻿{
+  "Name": "OrderIntent",
+  "Samples": [
+    "order {drink}",
+    "get {drink}",
+    "I'd like {drink}"
+  ]
+}

--- a/test/AlexaVoxCraft.Smapi.Tests/Snapshots/IntentBuilderTests.Build_WithMultipleSamplesViaWithSamples_IncludesAllSamples.verified.json
+++ b/test/AlexaVoxCraft.Smapi.Tests/Snapshots/IntentBuilderTests.Build_WithMultipleSamplesViaWithSamples_IncludesAllSamples.verified.json
@@ -1,0 +1,8 @@
+﻿{
+  "Name": "OrderIntent",
+  "Samples": [
+    "order {drink}",
+    "get {drink}",
+    "I'd like {drink}"
+  ]
+}

--- a/test/AlexaVoxCraft.Smapi.Tests/Snapshots/IntentBuilderTests.Build_WithMultipleSlots_IncludesAllSlots.verified.json
+++ b/test/AlexaVoxCraft.Smapi.Tests/Snapshots/IntentBuilderTests.Build_WithMultipleSlots_IncludesAllSlots.verified.json
@@ -1,0 +1,18 @@
+﻿{
+  "Name": "OrderIntent",
+  "Samples": [
+    "order {drink} in {size}"
+  ],
+  "Slots": [
+    {
+      "Name": "drink",
+      "Type": "DrinkType",
+      "IsRequired": false
+    },
+    {
+      "Name": "size",
+      "Type": "SizeType",
+      "IsRequired": false
+    }
+  ]
+}

--- a/test/AlexaVoxCraft.Smapi.Tests/Snapshots/IntentBuilderTests.Build_WithNoSamplesOrSlots_ReturnsIntentWithEmptyCollections.verified.json
+++ b/test/AlexaVoxCraft.Smapi.Tests/Snapshots/IntentBuilderTests.Build_WithNoSamplesOrSlots_ReturnsIntentWithEmptyCollections.verified.json
@@ -1,0 +1,3 @@
+﻿{
+  "Name": "OrderIntent"
+}

--- a/test/AlexaVoxCraft.Smapi.Tests/Snapshots/IntentBuilderTests.Build_WithSingleSample_IncludesSampleInResult.verified.json
+++ b/test/AlexaVoxCraft.Smapi.Tests/Snapshots/IntentBuilderTests.Build_WithSingleSample_IncludesSampleInResult.verified.json
@@ -1,0 +1,6 @@
+﻿{
+  "Name": "OrderIntent",
+  "Samples": [
+    "order {drink}"
+  ]
+}

--- a/test/AlexaVoxCraft.Smapi.Tests/Snapshots/IntentBuilderTests.Build_WithSingleSlot_IncludesSlotInResult.verified.json
+++ b/test/AlexaVoxCraft.Smapi.Tests/Snapshots/IntentBuilderTests.Build_WithSingleSlot_IncludesSlotInResult.verified.json
@@ -1,0 +1,13 @@
+﻿{
+  "Name": "OrderIntent",
+  "Samples": [
+    "order {drink}"
+  ],
+  "Slots": [
+    {
+      "Name": "drink",
+      "Type": "DrinkType",
+      "IsRequired": false
+    }
+  ]
+}

--- a/test/AlexaVoxCraft.Smapi.Tests/Snapshots/MultiLocaleInteractionModelBuilderTests.BuildAll_WithDuplicateForLocale_MergesIntoSameBuilder.verified.json
+++ b/test/AlexaVoxCraft.Smapi.Tests/Snapshots/MultiLocaleInteractionModelBuilderTests.BuildAll_WithDuplicateForLocale_MergesIntoSameBuilder.verified.json
@@ -1,0 +1,54 @@
+﻿[
+  {
+    "Locale": "en-US",
+    "Definition": {
+      "Version": "1",
+      "Description": "Duplicate locale merge test",
+      "InteractionModel": {
+        "LanguageModel": {
+          "InvocationName": "my skill",
+          "Intents": [
+            {
+              "Name": "FooIntent",
+              "Samples": [
+                "do foo"
+              ]
+            },
+            {
+              "Name": "BarIntent",
+              "Samples": [
+                "do bar"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "Locale": "en-GB",
+    "Definition": {
+      "Version": "1",
+      "Description": "Duplicate locale merge test",
+      "InteractionModel": {
+        "LanguageModel": {
+          "InvocationName": "my british skill",
+          "Intents": [
+            {
+              "Name": "FooIntent",
+              "Samples": [
+                "do foo differently"
+              ]
+            },
+            {
+              "Name": "BarIntent",
+              "Samples": [
+                "do bar"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/test/AlexaVoxCraft.Smapi.Tests/Snapshots/MultiLocaleInteractionModelBuilderTests.BuildAll_WithForLocaleAndNoLambda_InheritsAllFromDefault.verified.json
+++ b/test/AlexaVoxCraft.Smapi.Tests/Snapshots/MultiLocaleInteractionModelBuilderTests.BuildAll_WithForLocaleAndNoLambda_InheritsAllFromDefault.verified.json
@@ -1,0 +1,65 @@
+﻿[
+  {
+    "Locale": "en-US",
+    "Definition": {
+      "Version": "1",
+      "Description": "Inherit all from default",
+      "InteractionModel": {
+        "LanguageModel": {
+          "InvocationName": "my skill",
+          "Intents": [
+            {
+              "Name": "HelloIntent",
+              "Samples": [
+                "say hello",
+                "hello there"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "Locale": "en-CA",
+    "Definition": {
+      "Version": "1",
+      "Description": "Inherit all from default",
+      "InteractionModel": {
+        "LanguageModel": {
+          "InvocationName": "my skill",
+          "Intents": [
+            {
+              "Name": "HelloIntent",
+              "Samples": [
+                "say hello",
+                "hello there"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "Locale": "en-AU",
+    "Definition": {
+      "Version": "1",
+      "Description": "Inherit all from default",
+      "InteractionModel": {
+        "LanguageModel": {
+          "InvocationName": "my skill",
+          "Intents": [
+            {
+              "Name": "HelloIntent",
+              "Samples": [
+                "say hello",
+                "hello there"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/test/AlexaVoxCraft.Smapi.Tests/Snapshots/MultiLocaleInteractionModelBuilderTests.BuildAll_WithIntentSamplesOverride_AppliesOverrideForLocale.verified.json
+++ b/test/AlexaVoxCraft.Smapi.Tests/Snapshots/MultiLocaleInteractionModelBuilderTests.BuildAll_WithIntentSamplesOverride_AppliesOverrideForLocale.verified.json
@@ -1,0 +1,74 @@
+﻿[
+  {
+    "Locale": "en-US",
+    "Definition": {
+      "Version": "1",
+      "Description": "Intent samples override test",
+      "InteractionModel": {
+        "LanguageModel": {
+          "InvocationName": "my skill",
+          "Intents": [
+            {
+              "Name": "GreetIntent",
+              "Samples": [
+                "say hello",
+                "greet me"
+              ]
+            },
+            {
+              "Name": "AMAZON.StopIntent"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "Locale": "en-GB",
+    "Definition": {
+      "Version": "1",
+      "Description": "Intent samples override test",
+      "InteractionModel": {
+        "LanguageModel": {
+          "InvocationName": "my skill",
+          "Intents": [
+            {
+              "Name": "GreetIntent",
+              "Samples": [
+                "say hello",
+                "good day"
+              ]
+            },
+            {
+              "Name": "AMAZON.StopIntent"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "Locale": "en-CA",
+    "Definition": {
+      "Version": "1",
+      "Description": "Intent samples override test",
+      "InteractionModel": {
+        "LanguageModel": {
+          "InvocationName": "my skill",
+          "Intents": [
+            {
+              "Name": "GreetIntent",
+              "Samples": [
+                "say hello",
+                "greet me"
+              ]
+            },
+            {
+              "Name": "AMAZON.StopIntent"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/test/AlexaVoxCraft.Smapi.Tests/Snapshots/MultiLocaleInteractionModelBuilderTests.BuildAll_WithLocaleOverridingInvocationName_UsesOverrideForThatLocale.verified.json
+++ b/test/AlexaVoxCraft.Smapi.Tests/Snapshots/MultiLocaleInteractionModelBuilderTests.BuildAll_WithLocaleOverridingInvocationName_UsesOverrideForThatLocale.verified.json
@@ -1,0 +1,53 @@
+﻿[
+  {
+    "Locale": "en-US",
+    "Definition": {
+      "Version": "1",
+      "Description": "Invocation name override test",
+      "InteractionModel": {
+        "LanguageModel": {
+          "InvocationName": "my skill",
+          "Intents": [
+            {
+              "Name": "AMAZON.CancelIntent"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "Locale": "en-GB",
+    "Definition": {
+      "Version": "1",
+      "Description": "Invocation name override test",
+      "InteractionModel": {
+        "LanguageModel": {
+          "InvocationName": "my british skill",
+          "Intents": [
+            {
+              "Name": "AMAZON.CancelIntent"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "Locale": "en-CA",
+    "Definition": {
+      "Version": "1",
+      "Description": "Invocation name override test",
+      "InteractionModel": {
+        "LanguageModel": {
+          "InvocationName": "my skill",
+          "Intents": [
+            {
+              "Name": "AMAZON.CancelIntent"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/test/AlexaVoxCraft.Smapi.Tests/Snapshots/MultiLocaleInteractionModelBuilderTests.BuildAll_WithMultipleLocales_ReturnsAllLocales.verified.json
+++ b/test/AlexaVoxCraft.Smapi.Tests/Snapshots/MultiLocaleInteractionModelBuilderTests.BuildAll_WithMultipleLocales_ReturnsAllLocales.verified.json
@@ -1,0 +1,155 @@
+﻿[
+  {
+    "Locale": "en-US",
+    "Definition": {
+      "Version": "1",
+      "Description": "Multi-locale skill",
+      "InteractionModel": {
+        "LanguageModel": {
+          "InvocationName": "my skill",
+          "Intents": [
+            {
+              "Name": "OrderIntent",
+              "Samples": [
+                "order {drink}",
+                "get {drink}"
+              ],
+              "Slots": [
+                {
+                  "Name": "drink",
+                  "Type": "DrinkType",
+                  "IsRequired": false
+                }
+              ]
+            },
+            {
+              "Name": "AMAZON.CancelIntent"
+            },
+            {
+              "Name": "AMAZON.StopIntent"
+            }
+          ],
+          "Types": [
+            {
+              "Name": "DrinkType",
+              "Values": [
+                {
+                  "Name": {
+                    "Value": "coffee"
+                  }
+                },
+                {
+                  "Name": {
+                    "Value": "tea"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "Locale": "en-CA",
+    "Definition": {
+      "Version": "1",
+      "Description": "Multi-locale skill",
+      "InteractionModel": {
+        "LanguageModel": {
+          "InvocationName": "my skill",
+          "Intents": [
+            {
+              "Name": "OrderIntent",
+              "Samples": [
+                "order {drink}",
+                "get {drink}"
+              ],
+              "Slots": [
+                {
+                  "Name": "drink",
+                  "Type": "DrinkType",
+                  "IsRequired": false
+                }
+              ]
+            },
+            {
+              "Name": "AMAZON.CancelIntent"
+            },
+            {
+              "Name": "AMAZON.StopIntent"
+            }
+          ],
+          "Types": [
+            {
+              "Name": "DrinkType",
+              "Values": [
+                {
+                  "Name": {
+                    "Value": "coffee"
+                  }
+                },
+                {
+                  "Name": {
+                    "Value": "tea"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "Locale": "en-GB",
+    "Definition": {
+      "Version": "1",
+      "Description": "Multi-locale skill",
+      "InteractionModel": {
+        "LanguageModel": {
+          "InvocationName": "my skill",
+          "Intents": [
+            {
+              "Name": "OrderIntent",
+              "Samples": [
+                "order {drink}",
+                "I'd like {drink}"
+              ],
+              "Slots": [
+                {
+                  "Name": "drink",
+                  "Type": "DrinkType",
+                  "IsRequired": false
+                }
+              ]
+            },
+            {
+              "Name": "AMAZON.CancelIntent"
+            },
+            {
+              "Name": "AMAZON.StopIntent"
+            }
+          ],
+          "Types": [
+            {
+              "Name": "DrinkType",
+              "Values": [
+                {
+                  "Name": {
+                    "Value": "coffee"
+                  }
+                },
+                {
+                  "Name": {
+                    "Value": "tea"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/test/AlexaVoxCraft.Smapi.Tests/Snapshots/MultiLocaleInteractionModelBuilderTests.BuildAll_WithSingleDefaultLocale_ReturnsOneModel.verified.json
+++ b/test/AlexaVoxCraft.Smapi.Tests/Snapshots/MultiLocaleInteractionModelBuilderTests.BuildAll_WithSingleDefaultLocale_ReturnsOneModel.verified.json
@@ -1,0 +1,26 @@
+﻿[
+  {
+    "Locale": "en-US",
+    "Definition": {
+      "Version": "1",
+      "Description": "Single locale skill",
+      "InteractionModel": {
+        "LanguageModel": {
+          "InvocationName": "my skill",
+          "Intents": [
+            {
+              "Name": "HelloIntent",
+              "Samples": [
+                "say hello",
+                "hello"
+              ]
+            },
+            {
+              "Name": "AMAZON.CancelIntent"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/test/AlexaVoxCraft.Smapi.Tests/Snapshots/MultiLocaleInteractionModelBuilderTests.BuildAll_WithSlotSamplesOverride_AppliesOverrideForLocale.verified.json
+++ b/test/AlexaVoxCraft.Smapi.Tests/Snapshots/MultiLocaleInteractionModelBuilderTests.BuildAll_WithSlotSamplesOverride_AppliesOverrideForLocale.verified.json
@@ -1,0 +1,64 @@
+﻿[
+  {
+    "Locale": "en-US",
+    "Definition": {
+      "Version": "1",
+      "Description": "Slot samples override test",
+      "InteractionModel": {
+        "LanguageModel": {
+          "InvocationName": "my skill",
+          "Intents": [
+            {
+              "Name": "OrderIntent",
+              "Samples": [
+                "order {item}"
+              ],
+              "Slots": [
+                {
+                  "Name": "item",
+                  "Type": "AMAZON.Food",
+                  "IsRequired": false,
+                  "Samples": [
+                    "coffee",
+                    "sandwich"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "Locale": "en-GB",
+    "Definition": {
+      "Version": "1",
+      "Description": "Slot samples override test",
+      "InteractionModel": {
+        "LanguageModel": {
+          "InvocationName": "my skill",
+          "Intents": [
+            {
+              "Name": "OrderIntent",
+              "Samples": [
+                "order {item}"
+              ],
+              "Slots": [
+                {
+                  "Name": "item",
+                  "Type": "AMAZON.Food",
+                  "IsRequired": false,
+                  "Samples": [
+                    "tea",
+                    "biscuit"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/test/AlexaVoxCraft.Smapi.Tests/Snapshots/MultiLocaleInteractionModelBuilderTests.BuildAll_WithSlotValuesOverride_AppliesOverrideForLocale.verified.json
+++ b/test/AlexaVoxCraft.Smapi.Tests/Snapshots/MultiLocaleInteractionModelBuilderTests.BuildAll_WithSlotValuesOverride_AppliesOverrideForLocale.verified.json
@@ -1,0 +1,90 @@
+﻿[
+  {
+    "Locale": "en-US",
+    "Definition": {
+      "Version": "1",
+      "Description": "Slot values override test",
+      "InteractionModel": {
+        "LanguageModel": {
+          "InvocationName": "my skill",
+          "Intents": [
+            {
+              "Name": "OrderIntent",
+              "Samples": [
+                "order {drink}"
+              ],
+              "Slots": [
+                {
+                  "Name": "drink",
+                  "Type": "DrinkType",
+                  "IsRequired": false
+                }
+              ]
+            }
+          ],
+          "Types": [
+            {
+              "Name": "DrinkType",
+              "Values": [
+                {
+                  "Name": {
+                    "Value": "soda"
+                  }
+                },
+                {
+                  "Name": {
+                    "Value": "coffee"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "Locale": "en-GB",
+    "Definition": {
+      "Version": "1",
+      "Description": "Slot values override test",
+      "InteractionModel": {
+        "LanguageModel": {
+          "InvocationName": "my skill",
+          "Intents": [
+            {
+              "Name": "OrderIntent",
+              "Samples": [
+                "order {drink}"
+              ],
+              "Slots": [
+                {
+                  "Name": "drink",
+                  "Type": "DrinkType",
+                  "IsRequired": false
+                }
+              ]
+            }
+          ],
+          "Types": [
+            {
+              "Name": "DrinkType",
+              "Values": [
+                {
+                  "Name": {
+                    "Value": "fizzy drink"
+                  }
+                },
+                {
+                  "Name": {
+                    "Value": "coffee"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary

Adds `MultiLocaleInteractionModelBuilder` to `AlexaVoxCraft.Smapi`, enabling Alexa skills targeting multiple locales to define their interaction model schema once and provide only locale-specific text (invocation name, sample utterances, slot values) per locale. Unoverridden values fall back to the default locale, following the `.resx` resource file mental model. Also adds `LocalizedInteractionModel` as a pairing type and new `UpdateAsync`/`UpdateAllAsync` overloads on the client for ergonomic batch publishing.

## Changes

**New types**
- `LocalizedInteractionModel` — record pairing a locale string with an `InteractionModelDefinition`
- `LocaleOverrideBuilder` — builder for locale-specific text overrides; validates intent/slot/slot-type names against the schema at call time (fail-fast)
- `MultiLocaleInteractionModelBuilder` — shared schema + `WithDefaultLocale`/`ForLocale`/`BuildAll()`

**Existing builder additions (non-breaking)**
- `InteractionModelBuilder.WithLocale(string)` + `BuildLocalized()` for single-locale locale-aware builds
- `internal` members on `IntentBuilder` and `SlotBuilder` (`Name`, `SlotNames`, `BuildWithSamples`) to support locale-aware construction without mutating shared builder state

**Client additions**
- `IAlexaInteractionModelClient.UpdateAsync(skillId, stage, LocalizedInteractionModel, ct)` — extracts locale from the record
- `IAlexaInteractionModelClient.UpdateAllAsync(skillId, stage, IEnumerable<LocalizedInteractionModel>, ct)` — sequential push; collects all per-locale errors into an `AggregateException` so every locale is attempted regardless of partial failures; honours cancellation immediately

**Docs**
- `docs/adr/` — ADR index, template, and ADR-0001 documenting the design decision and alternatives considered
- `docs/plans/` — full implementation plan

**Version bump:** `7.2.0` → `7.3.0` (additive minor, no breaking changes)

## Validation

- All 60 tests pass (`dotnet run --project test/AlexaVoxCraft.Smapi.Tests --framework net9.0`)
- 12 new tests for `MultiLocaleInteractionModelBuilder`: 8 snapshot tests covering fallback resolution, locale overrides, duplicate locale merging, and no-lambda inheritance; 4 exception tests for missing default locale and unknown intent/slot/slot-type names
- 2 new tests for `InteractionModelBuilder.BuildLocalized`
- 4 new client tests including `UpdateAllAsync_WhenSomeLocalesFail_ThrowsAggregateExceptionAfterAttemptingAll`

## Release Notes

**`AlexaVoxCraft.Smapi` 7.3.0**

New `MultiLocaleInteractionModelBuilder` for skills targeting multiple locales:

```csharp
var models = MultiLocaleInteractionModelBuilder.Create()
    .WithVersion("1").WithDescription("My skill")
    .AddIntent("OrderIntent", i => i.WithSlot("drink", "DrinkType"))
    .AddIntent(BuiltInIntent.Cancel)
    .AddSlotType("DrinkType")
    .WithDefaultLocale("en-US", locale => locale
        .WithInvocationName("my skill")
        .WithIntentSamples("OrderIntent", "order {drink}", "get {drink}")
        .WithSlotValues("DrinkType", v => v.WithValue("coffee").WithValue("tea")))
    .ForLocale("en-CA")                    // inherits everything from en-US
    .ForLocale("en-GB", locale => locale
        .WithIntentSamples("OrderIntent", "order {drink}", "I'd like {drink}"))
    .BuildAll();

await client.UpdateAllAsync(skillId, "development", models, ct);
```

🤖 Generated with [Claude Code](https://claude.ai/code)