### PR TITLE
fix: change IAccessTokenProvider lifetime to scoped and bump patch version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>7.2.0</VersionPrefix>
+        <VersionPrefix>7.2.1</VersionPrefix>
         <!-- SPDX license identifier for Apache 2.0 -->
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,9 +18,9 @@
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
   </ItemGroup>
   <ItemGroup Label="OpenTelemetry">
-    <PackageVersion Include="OpenTelemetry" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.1" />
   </ItemGroup>
   <ItemGroup Label="Microsoft">
     <PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />
@@ -53,7 +53,7 @@
   </ItemGroup>
   <ItemGroup Label="Verify">
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
-    <PackageVersion Include="Verify.XunitV3" Version="31.13.5" />
+    <PackageVersion Include="Verify.XunitV3" Version="31.15.0" />
   </ItemGroup>
   <ItemGroup Label="Testing">
     <PackageVersion Include="AutoFixture" Version="4.18.1" />

--- a/src/AlexaVoxCraft.InSkillPurchasing/ServiceCollectionExtensions.cs
+++ b/src/AlexaVoxCraft.InSkillPurchasing/ServiceCollectionExtensions.cs
@@ -25,7 +25,7 @@ public static class ServiceCollectionExtensions
                 })
                 .AddLocale()
                 .AddAuthorizationForwarding();
-            services.AddSingleton<IAccessTokenProvider, AlexaRequestAccessTokenProvider>();
+            services.AddScoped<IAccessTokenProvider, AlexaRequestAccessTokenProvider>();
             return services;
         }
     }

--- a/src/AlexaVoxCraft.Smapi/ServiceCollectionExtensions.cs
+++ b/src/AlexaVoxCraft.Smapi/ServiceCollectionExtensions.cs
@@ -57,7 +57,7 @@ public static class ServiceCollectionExtensions
                     client.BaseAddress = new Uri("https://api.amazonalexa.com/");
                 })
                 .AddAuthorizationForwarding();
-            services.AddSingleton<IAccessTokenProvider, SmapiDeveloperAccessTokenProvider>();
+            services.AddScoped<IAccessTokenProvider, SmapiDeveloperAccessTokenProvider>();
             return services;
         }
 
@@ -105,7 +105,7 @@ public static class ServiceCollectionExtensions
                     client.BaseAddress = new Uri("https://api.amazonalexa.com/");
                 })
                 .AddAuthorizationForwarding();
-            services.AddSingleton<IAccessTokenProvider, SmapiDeveloperAccessTokenProvider>();
+            services.AddScoped<IAccessTokenProvider, SmapiDeveloperAccessTokenProvider>();
             return services;
         }
     }


### PR DESCRIPTION
## Summary

`IAccessTokenProvider` was registered as a singleton in both `AlexaVoxCraft.InSkillPurchasing` and `AlexaVoxCraft.Smapi`, which is incorrect since access tokens are per-request in the Alexa/SMAPI context. This PR changes both registrations to `AddScoped` to ensure proper per-request lifetime isolation. The version is bumped to `7.2.1` to reflect the patch fix, and a few dependency updates are included.

## Changes

**DI Lifetime Fix**
- `AlexaVoxCraft.InSkillPurchasing`: `AlexaRequestAccessTokenProvider` changed from `AddSingleton` → `AddScoped`
- `AlexaVoxCraft.Smapi`: `SmapiDeveloperAccessTokenProvider` changed from `AddSingleton` → `AddScoped` (both `AddSmapi` overloads)

**Version & Dependencies**
- `Directory.Build.props`: `VersionPrefix` bumped `7.2.0` → `7.2.1`
- `OpenTelemetry`, `OpenTelemetry.Api`, `OpenTelemetry.Exporter.InMemory`: `1.15.0` → `1.15.1`
- `Verify.XunitV3`: `31.13.5` → `31.15.0`

## Validation

- Build: `dotnet build AlexaVoxCraft.sln`
- The singleton → scoped change is a correctness fix; singleton access token providers would cache the first request's token and serve it to all subsequent requests

## Notes for Reviewers

The singleton lifetime for `IAccessTokenProvider` is a latent bug — it would only surface under concurrent requests or request reuse scenarios (e.g., warm Lambda containers serving multiple invocations). Scoped is the correct lifetime since the provider resolves the token from the current HTTP/request context.