### PR TITLE
chore(deps,ci): update packages from v7.3.3 baseline, pin workflows to v8.2, bump version to 7.3.4

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -7,7 +7,7 @@ on:
 permissions: write-all
 jobs:
   build:
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@main
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v8.2
     with:
       solution: AlexaVoxCraft.slnx
       hasTests: true

--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   validate:
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-title-check.yml@main
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-title-check.yml@v8.2

--- a/.github/workflows/publish-preview.yaml
+++ b/.github/workflows/publish-preview.yaml
@@ -12,7 +12,7 @@ permissions: write-all
 
 jobs:
   publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@main
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v8.2
     with:
       solution: AlexaVoxCraft.slnx
       dotnetVersion: |

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -8,7 +8,7 @@ permissions: write-all
 
 jobs:
   publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@main
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@v8.2
     with:
       solution: AlexaVoxCraft.slnx
       dotnetVersion: |

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   draft:
-    uses: LayeredCraft/devops-templates/.github/workflows/release-drafter.yml@main
+    uses: LayeredCraft/devops-templates/.github/workflows/release-drafter.yml@v8.2
     with:
       event_name: ${{ github.event_name }}
       pr_draft: ${{ github.event.pull_request.draft == true }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>7.3.0</VersionPrefix>
+        <VersionPrefix>7.3.4</VersionPrefix>
         <!-- SPDX license identifier for Apache 2.0 -->
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,13 +3,13 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup Label="AWS Lambda">
-    <PackageVersion Include="Amazon.Lambda.Core" Version="2.8.1" />
-    <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="1.14.3" />
-    <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.5" />
+    <PackageVersion Include="Amazon.Lambda.Core" Version="3.0.0" />
+    <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="2.0.0" />
+    <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup Label="LayeredCraft">
-    <PackageVersion Include="LayeredCraft.Logging.CompactJsonFormatter" Version="1.1.1" />
-    <PackageVersion Include="LayeredCraft.StructuredLogging" Version="1.2.0" />
+    <PackageVersion Include="LayeredCraft.Logging.CompactJsonFormatter" Version="1.1.2" />
+    <PackageVersion Include="LayeredCraft.StructuredLogging" Version="1.2.1" />
   </ItemGroup>
   <ItemGroup Label="Serilog">
     <PackageVersion Include="Serilog" Version="4.3.1" />
@@ -24,7 +24,7 @@
   </ItemGroup>
   <ItemGroup Label="Microsoft">
     <PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.203" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
   </ItemGroup>
   <ItemGroup Label="Microsoft Extensions (net8.0)" Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1'">
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
@@ -34,25 +34,25 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
   </ItemGroup>
   <ItemGroup Label="Microsoft Extensions (net9.0)" Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.15" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.15" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.15" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.15" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.15" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.16" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.16" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.16" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.16" />
   </ItemGroup>
   <ItemGroup Label="Microsoft Extensions (net10.0)" Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.8" />
   </ItemGroup>
   <ItemGroup Label="Microsoft Extensions (net11.0)" Condition="'$(TargetFramework)' == 'net11.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="11.0.0-preview.3.26207.106" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.3.26207.106" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="11.0.0-preview.3.26207.106" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="11.0.0-preview.3.26207.106" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="11.0.0-preview.3.26207.106" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="11.0.0-preview.4.26230.115" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.4.26230.115" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="11.0.0-preview.4.26230.115" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="11.0.0-preview.4.26230.115" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="11.0.0-preview.4.26230.115" />
   </ItemGroup>
   <ItemGroup Label="Roslyn / Source Generators">
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
@@ -60,7 +60,7 @@
   </ItemGroup>
   <ItemGroup Label="Verify">
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
-    <PackageVersion Include="Verify.XunitV3" Version="31.16.2" />
+    <PackageVersion Include="Verify.XunitV3" Version="31.16.3" />
   </ItemGroup>
   <ItemGroup Label="Testing">
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
@@ -73,12 +73,12 @@
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
   <ItemGroup Label="Reference Assemblies">
-      <PackageVersion Include="Basic.Reference.Assemblies.Net110" Version="1.8.6" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.6" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.6" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.6" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.7" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.7" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.7" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net110" Version="1.8.7" />
   </ItemGroup>
   <ItemGroup Label="Utilities">
-    <PackageVersion Include="MinimalLambda" Version="2.4.0" />
+    <PackageVersion Include="MinimalLambda" Version="2.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary

Clean package update from the `v7.3.3` baseline with correct `Microsoft.CodeAnalysis.CSharp` pin.

Key updates:
- **AWS Lambda** packages bumped to v3 (Core, RuntimeSupport, Serialization)
- **Microsoft.Extensions.\*** updated for net9 (9.0.16), net10 (10.0.8), net11 (preview.4)
- **Basic.Reference.Assemblies.\*** bumped to 1.8.7
- **LayeredCraft** packages updated (CompactJsonFormatter 1.1.2, StructuredLogging 1.2.1)
- `Microsoft.CodeAnalysis.CSharp` **kept at `[5.0.0]`** — 5.3.0 has a known bug that breaks interceptors
- Misc: Verify.XunitV3 31.16.3, Microsoft.NET.Test.Sdk 18.5.1, MinimalLambda 2.5.0, SourceLink 10.0.300
- All devops-template workflow refs pinned from `@main` to `@v8.2`
- `VersionPrefix` bumped to `7.3.4`

---

## ✅ Checklist

- [ ] My changes build cleanly
- [ ] I've added/updated relevant tests
- [ ] I've added/updated documentation or README
- [x] I've followed the coding style for this project
- [ ] I've tested the changes locally (if applicable)

---

## 🧪 Related Issues or PRs

Replaces #160 (which incorrectly changed `Microsoft.CodeAnalysis.CSharp` to `[5.3.0]`).

---

## 💬 Notes for Reviewers

`Microsoft.CodeAnalysis.CSharp` is intentionally pinned at `[5.0.0]` — 5.3.0 breaks source generator interceptors. AWS Lambda major version bump (v2 → v3) is the other high-risk change.