### PR TITLE
chore(deps): update dependency baselines

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup Label="AWS Lambda">
-    <PackageVersion Include="Amazon.Lambda.Core" Version="3.0.0" />
-    <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="2.0.0" />
+    <PackageVersion Include="Amazon.Lambda.Core" Version="3.1.0" />
+    <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="2.1.0" />
     <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup Label="LayeredCraft">
@@ -60,7 +60,7 @@
   </ItemGroup>
   <ItemGroup Label="Verify">
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
-    <PackageVersion Include="Verify.XunitV3" Version="31.16.3" />
+    <PackageVersion Include="Verify.XunitV3" Version="31.17.0" />
   </ItemGroup>
   <ItemGroup Label="Testing">
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
@@ -73,10 +73,10 @@
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
   <ItemGroup Label="Reference Assemblies">
-    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.7" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.7" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.7" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net110" Version="1.8.7" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.8" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.8" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.8" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net110" Version="1.8.8" />
   </ItemGroup>
   <ItemGroup Label="Utilities">
     <PackageVersion Include="MinimalLambda" Version="2.5.0" />

--- a/test/AlexaVoxCraft.MediatR.Generator.Tests/AlexaVoxCraft.MediatR.Generator.Tests.csproj
+++ b/test/AlexaVoxCraft.MediatR.Generator.Tests/AlexaVoxCraft.MediatR.Generator.Tests.csproj
@@ -40,12 +40,12 @@
       <Folder Include="Snapshots\" />
     </ItemGroup>
     
-    <ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">
-        <PackageReference Include="Basic.Reference.Assemblies.Net110" />
-    </ItemGroup>
-
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
       <PackageReference Include="Basic.Reference.Assemblies.Net100" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">
+      <PackageReference Include="Basic.Reference.Assemblies.Net110" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">


### PR DESCRIPTION
## Summary

Updates dependency baselines for AWS Lambda runtime packages, Verify.XunitV3, and Basic.Reference.Assemblies. This keeps central package management current while preserving the existing multi-targeted generator test setup.

## Changes

- Bumped `Amazon.Lambda.Core` to `3.1.0` and `Amazon.Lambda.RuntimeSupport` to `2.1.0`.
- Bumped `Verify.XunitV3` to `31.17.0`.
- Bumped `Basic.Reference.Assemblies` package baselines to `1.8.8` for `net8.0`, `net9.0`, `net10.0`, and `net11.0`.
- Normalized the `net11.0` reference assembly item ordering/indentation in the MediatR generator test project.

## Validation

- `dotnet restore AlexaVoxCraft.slnx`
- `dotnet build AlexaVoxCraft.slnx --no-restore` (passes with existing warnings)
- `dotnet run --project test/AlexaVoxCraft.MediatR.Generator.Tests/AlexaVoxCraft.MediatR.Generator.Tests.csproj --framework net10.0`