### PR TITLE
ci: upgrade devops-templates to v10.0 with NuGet trusted publishing

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -7,7 +7,7 @@ on:
 permissions: write-all
 jobs:
   build:
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v8.2
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v10.0
     with:
       solution: AlexaVoxCraft.slnx
       hasTests: true

--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   validate:
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-title-check.yml@v8.2
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-title-check.yml@v10.0

--- a/.github/workflows/publish-preview.yaml
+++ b/.github/workflows/publish-preview.yaml
@@ -8,11 +8,13 @@ on:
       - 'docs/**'
       - 'README.md'
 
-permissions: write-all
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
-  publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v8.2
+  build:
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v10.0
     with:
       solution: AlexaVoxCraft.slnx
       dotnetVersion: |
@@ -22,3 +24,14 @@ jobs:
         11.0.x
       hasTests: true
     secrets: inherit
+
+  push:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: LayeredCraft/devops-templates/.github/actions/nuget-push@v10.0
+        with:
+          nuget_user: ${{ secrets.NUGET_USER }}

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -4,11 +4,12 @@ on:
   release:
     types: [published]
 
-permissions: write-all
+permissions:
+  contents: write
 
 jobs:
-  publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@v8.2
+  build:
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@v10.0
     with:
       solution: AlexaVoxCraft.slnx
       dotnetVersion: |
@@ -18,3 +19,14 @@ jobs:
         11.0.x
       hasTests: true
     secrets: inherit
+
+  push:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: LayeredCraft/devops-templates/.github/actions/nuget-push@v10.0
+        with:
+          nuget_user: ${{ secrets.NUGET_USER }}

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   draft:
-    uses: LayeredCraft/devops-templates/.github/workflows/release-drafter.yml@v8.2
+    uses: LayeredCraft/devops-templates/.github/workflows/release-drafter.yml@v10.0
     with:
       event_name: ${{ github.event_name }}
       pr_draft: ${{ github.event.pull_request.draft == true }}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,13 +3,13 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup Label="AWS Lambda">
-    <PackageVersion Include="Amazon.Lambda.Core" Version="3.1.0" />
-    <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="2.1.0" />
+    <PackageVersion Include="Amazon.Lambda.Core" Version="3.1.1" />
+    <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="2.1.2" />
     <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup Label="LayeredCraft">
-    <PackageVersion Include="LayeredCraft.Logging.CompactJsonFormatter" Version="1.1.2" />
-    <PackageVersion Include="LayeredCraft.StructuredLogging" Version="1.2.1" />
+    <PackageVersion Include="LayeredCraft.Logging.CompactJsonFormatter" Version="1.1.3" />
+    <PackageVersion Include="LayeredCraft.StructuredLogging" Version="1.2.3" />
   </ItemGroup>
   <ItemGroup Label="Serilog">
     <PackageVersion Include="Serilog" Version="4.3.1" />
@@ -18,9 +18,9 @@
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
   </ItemGroup>
   <ItemGroup Label="OpenTelemetry">
-    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.16.0" />
   </ItemGroup>
   <ItemGroup Label="Microsoft">
     <PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />
@@ -34,25 +34,25 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
   </ItemGroup>
   <ItemGroup Label="Microsoft Extensions (net9.0)" Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.16" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.16" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.16" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.16" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.17" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.17" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.17" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.17" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.17" />
   </ItemGroup>
   <ItemGroup Label="Microsoft Extensions (net10.0)" Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
   </ItemGroup>
   <ItemGroup Label="Microsoft Extensions (net11.0)" Condition="'$(TargetFramework)' == 'net11.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="11.0.0-preview.4.26230.115" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.4.26230.115" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="11.0.0-preview.4.26230.115" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="11.0.0-preview.4.26230.115" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="11.0.0-preview.4.26230.115" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="11.0.0-preview.5.26302.115" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.5.26302.115" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="11.0.0-preview.5.26302.115" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="11.0.0-preview.5.26302.115" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="11.0.0-preview.5.26302.115" />
   </ItemGroup>
   <ItemGroup Label="Roslyn / Source Generators">
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
@@ -60,25 +60,25 @@
   </ItemGroup>
   <ItemGroup Label="Verify">
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
-    <PackageVersion Include="Verify.XunitV3" Version="31.17.0" />
+    <PackageVersion Include="Verify.XunitV3" Version="31.20.0" />
   </ItemGroup>
   <ItemGroup Label="Testing">
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.Xunit3" Version="4.19.0" />
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
   <ItemGroup Label="Reference Assemblies">
-    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.8" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.8" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.8" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net110" Version="1.8.8" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.9" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.9" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.9" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net110" Version="1.8.9" />
   </ItemGroup>
   <ItemGroup Label="Utilities">
-    <PackageVersion Include="MinimalLambda" Version="2.5.0" />
+    <PackageVersion Include="MinimalLambda" Version="2.6.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Upgrades all `devops-templates` references from `v8.2` to `v10.0` and converts the publish flows to use NuGet Trusted Publishing (OIDC) via the `nuget-push` composite action. Also includes pending package updates from `Directory.Packages.props`.

## Changes

**`publish-preview.yaml` and `publish-release.yaml`** — structural change
- Renamed `publish` job to `build`; shared template now handles build/test/pack/artifact upload only
- Added `push` job using `nuget-push@v10.0` composite action for OIDC login and NuGet push
- Tightened `permissions: write-all` to least-privilege per job

**`pr-build.yaml`, `pr-title-check.yaml`, `release-drafter.yaml`** — version bump only
- `@v8.2` → `@v10.0`, no other changes

**`Directory.Packages.props`** — package updates

## Validation

The `build` + `push` job pattern was validated end-to-end on `LayeredCraft/compact-json-formatter` with the same template version and composite action before applying here.

## Notes for Reviewers

NuGet.org trusted publisher entries for this repo will need to be configured pointing at `.github/workflows/publish-preview.yaml` and `.github/workflows/publish-release.yaml` before the push jobs will succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)