### PR TITLE
chore(deps): bump package versions and ignore TFM-conditional deps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,13 @@ updates:
           - "major"
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "Serilog.AspNetCore"
+      - dependency-name: "Microsoft.Extensions.Configuration.Binder"
+      - dependency-name: "Microsoft.Extensions.DependencyInjection.Abstractions"
+      - dependency-name: "Microsoft.Extensions.Hosting"
+      - dependency-name: "Microsoft.Extensions.Http"
+      - dependency-name: "Microsoft.Extensions.Options"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,23 +3,23 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup Label="AWS Lambda">
-    <PackageVersion Include="Amazon.Lambda.Core" Version="3.1.1" />
+    <PackageVersion Include="Amazon.Lambda.Core" Version="3.2.0" />
     <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="2.1.2" />
     <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup Label="LayeredCraft">
     <PackageVersion Include="LayeredCraft.Logging.CompactJsonFormatter" Version="1.1.3" />
-    <PackageVersion Include="LayeredCraft.StructuredLogging" Version="1.2.3" />
+    <PackageVersion Include="LayeredCraft.StructuredLogging" Version="1.2.4" />
   </ItemGroup>
   <ItemGroup Label="Serilog">
-    <PackageVersion Include="Serilog" Version="4.3.1" />
+    <PackageVersion Include="Serilog" Version="4.4.0" />
     <PackageVersion Include="Serilog.Enrichers.Activity" Version="1.0.0.3" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
   </ItemGroup>
   <ItemGroup Label="OpenTelemetry">
-    <PackageVersion Include="OpenTelemetry" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.17.0" />
   </ItemGroup>
   <ItemGroup Label="Serilog.AspNetCore (net8.0)" Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1'">
     <PackageVersion Include="Serilog.AspNetCore" Version="[8.0.3, 9.0.0)" />
@@ -32,7 +32,7 @@
   </ItemGroup>
   <ItemGroup Label="Microsoft">
     <PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
   </ItemGroup>
   <!-- Microsoft.Extensions.* packages ship parallel stable and preview build lines.
        Pin each per-TargetFramework with bounded ranges so Dependabot can raise
@@ -45,53 +45,53 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="[8.0.2, 9.0.0)" />
   </ItemGroup>
   <ItemGroup Label="Microsoft Extensions (net9.0)" Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="[9.0.17, 10.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[9.0.17, 10.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[9.0.17, 10.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="[9.0.17, 10.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="[9.0.17, 10.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="[9.0.18, 10.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[9.0.18, 10.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[9.0.18, 10.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="[9.0.18, 10.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="[9.0.18, 10.0.0)" />
   </ItemGroup>
   <ItemGroup Label="Microsoft Extensions (net10.0)" Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="[10.0.9, 11.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[10.0.9, 11.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[10.0.9, 11.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="[10.0.9, 11.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="[10.0.9, 11.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="[10.0.10, 11.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[10.0.10, 11.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[10.0.10, 11.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="[10.0.10, 11.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="[10.0.10, 11.0.0)" />
   </ItemGroup>
   <!-- Lower bound is a prerelease, which causes NuGet to consider prerelease
        candidates for these package IDs. Use a letter-led prerelease marker on
        the exclusive upper bound so the ranges stay below all 12.0.0 previews
        as well as 12.0.0 stable. -->
   <ItemGroup Label="Microsoft Extensions (net11.0)" Condition="'$(TargetFramework)' == 'net11.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="[11.0.0-preview.5.26302.115, 12.0.0-a)" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[11.0.0-preview.5.26302.115, 12.0.0-a)" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[11.0.0-preview.5.26302.115, 12.0.0-a)" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="[11.0.0-preview.5.26302.115, 12.0.0-a)" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="[11.0.0-preview.5.26302.115, 12.0.0-a)" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="[11.0.0-preview.6.26359.118, 12.0.0-a)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[11.0.0-preview.6.26359.118, 12.0.0-a)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[11.0.0-preview.6.26359.118, 12.0.0-a)" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="[11.0.0-preview.6.26359.118, 12.0.0-a)" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="[11.0.0-preview.6.26359.118, 12.0.0-a)" />
   </ItemGroup>
   <ItemGroup Label="Roslyn / Source Generators">
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="[5.0.0]" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
   </ItemGroup>
   <ItemGroup Label="Verify">
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
-    <PackageVersion Include="Verify.XunitV3" Version="31.20.0" />
+    <PackageVersion Include="Verify.XunitV3" Version="31.27.0" />
   </ItemGroup>
   <ItemGroup Label="Testing">
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.Xunit3" Version="4.19.0" />
-    <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.5.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageVersion Include="NSubstitute" Version="6.0.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
   <ItemGroup Label="Reference Assemblies">
-    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.9" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.9" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.9" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net110" Version="1.8.9" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.10" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.10" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.10" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net110" Version="1.8.10" />
   </ItemGroup>
   <ItemGroup Label="Utilities">
     <PackageVersion Include="MinimalLambda" Version="2.6.0" />

--- a/test/AlexaVoxCraft.TestKit/AlexaVoxCraft.TestKit.csproj
+++ b/test/AlexaVoxCraft.TestKit/AlexaVoxCraft.TestKit.csproj
@@ -15,7 +15,9 @@
       <PackageReference Include="AutoFixture.AutoNSubstitute" />
       <PackageReference Include="AutoFixture.Xunit3" />
       <PackageReference Include="AwesomeAssertions" />
-      <PackageReference Include="NSubstitute" />
+        <PackageReference Include="NSubstitute">
+            <NoWarn>NU1608</NoWarn>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- Bumps several NuGet package versions in `Directory.Packages.props` (Amazon.Lambda.Core, Serilog, OpenTelemetry, Microsoft.SourceLink.GitHub, Microsoft.Extensions.* TFM ranges, Roslyn, Verify, testing packages, reference assemblies).
- Adds an `ignore` list to the `nuget` update block in `.github/dependabot.yml` for packages pinned per-`TargetFramework` (`Serilog.AspNetCore`, `Microsoft.Extensions.Configuration.Binder`, `.DependencyInjection.Abstractions`, `.Hosting`, `.Http`, `.Options`).
- Suppresses `NU1608` on the `NSubstitute` reference in `AlexaVoxCraft.TestKit.csproj`.

## Why
Dependabot doesn't understand the per-`TargetFramework` `Condition` version ranges for these packages — an automated bump would either miss the multi-TFM structure or clobber one of the bounded ranges. Ignoring them keeps those bumps manual and intentional.

## Changes
- `.github/dependabot.yml`: `ignore` entries for the 6 TFM-conditional package IDs under the `nuget` ecosystem.
- `Directory.Packages.props`: routine version bumps (see diff).
- `test/AlexaVoxCraft.TestKit/AlexaVoxCraft.TestKit.csproj`: `NoWarn` for `NU1608` on `NSubstitute`.

## Validation
- Not yet built/tested locally — recommend CI run before merge.

## Notes for Reviewers
`Microsoft.CodeAnalysis.CSharp` moved from the exact pin `[5.0.0]` to an open `5.6.0`. Prior guidance was to keep this pinned at `5.0.0` because `5.3.0+` broke interceptors — worth confirming that's no longer an issue before merging, since this PR removes that safety pin.