### PR TITLE
ci(github): rework release-drafter categories and label scheme

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,71 +1,94 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
-categories:
-  - title: '🚀 Features'
-    labels:
-      - 'feat'
-      - 'feature'
-  - title: '🐛 Bug Fixes'
-    labels:
-      - 'fix'
-      - 'bug'
-  - title: '🧹 Maintenance'
-    labels:
-      - 'chore'
-      - 'refactor'
-      - 'deps'
-  - title: '📖 Documentation'
-    labels:
-      - 'docs'
-      - 'documentation'
-  - title: '🔧 CI/CD'
-    labels:
-      - 'ci'
-      - 'build'
-autolabeler:
-  - label: 'feat'
-    title:
-      - '/^feat(\(.+\))?:/i'
-  - label: 'fix'
-    title:
-      - '/^fix(\(.+\))?:/i'
-  - label: 'docs'
-    title:
-      - '/^docs(\(.+\))?:/i'
-  - label: 'chore'
-    title:
-      - '/^chore(\(.+\))?:/i'
-  - label: 'refactor'
-    title:
-      - '/^refactor(\(.+\))?:/i'
-  - label: 'ci'
-    title:
-      - '/^ci(\(.+\))?:/i'
-  - label: 'deps'
-    title:
-      - '/^(chore|build)(\(deps\))?:/i'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&'
+commitish: main
+
 version-resolver:
   major:
     labels:
-      - 'breaking'
-      - 'major'
+      - 'breaking-change'
   minor:
     labels:
-      - 'feat'
-      - 'feature'
+      - 'type: feat'
   patch:
     labels:
-      - 'fix'
-      - 'bug'
-      - 'chore'
-      - 'refactor'
-      - 'deps'
-      - 'docs'
-      - 'ci'
-      - 'build'
+      - 'type: fix'
+      - 'type: docs'
+      - 'type: refactor'
+      - 'type: test'
+      - 'type: chore'
+      - 'type: ci'
+      - 'type: revert'
   default: patch
+
+autolabeler:
+  - label: 'type: feat'
+    title:
+      - '/^feat(\(.+\))?(!)?:/i'
+  - label: 'type: fix'
+    title:
+      - '/^fix(\(.+\))?(!)?:/i'
+  - label: 'type: docs'
+    title:
+      - '/^docs(\(.+\))?(!)?:/i'
+  - label: 'type: refactor'
+    title:
+      - '/^refactor(\(.+\))?(!)?:/i'
+  - label: 'type: test'
+    title:
+      - '/^test(\(.+\))?(!)?:/i'
+  - label: 'type: chore'
+    title:
+      - '/^chore(\(.+\))?(!)?:/i'
+  - label: 'type: ci'
+    title:
+      - '/^ci(\(.+\))?(!)?:/i'
+  - label: 'type: revert'
+    title:
+      - '/^revert(\(.+\))?(!)?:/i'
+  - label: 'breaking-change'
+    title:
+      - '/^(feat|fix|docs|refactor|test|chore|ci|revert)(\([^)]*\))?!:/i'
+
+categories:
+  - title: '⚠️ Breaking Changes'
+    labels:
+      - 'breaking-change'
+  - title: '🚀 Features'
+    labels:
+      - 'type: feat'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'type: fix'
+  - title: '📚 Documentation'
+    labels:
+      - 'type: docs'
+  - title: '🔄 Refactoring'
+    labels:
+      - 'type: refactor'
+  - title: '✅ Tests'
+    labels:
+      - 'type: test'
+  - title: '🔧 Maintenance'
+    labels:
+      - 'type: chore'
+      - 'type: ci'
+      - 'type: revert'
+
+include-labels:
+  - 'type: feat'
+  - 'type: fix'
+  - 'type: docs'
+  - 'type: refactor'
+  - 'type: test'
+  - 'type: chore'
+  - 'type: ci'
+  - 'type: revert'
+  - 'breaking-change'
+
+exclude-labels:
+  - 'skip-changelog'
+  - 'internal'
+
 template: |
   ## Changes
 


### PR DESCRIPTION
## 📋 Summary

Reworks `.github/release-drafter.yml` to use `type: <x>` prefixed labels (matching current PR labeling conventions) instead of bare labels like `feat`/`fix`/`chore`. Adds a proper version-resolver mapping, breaking-change detection/category, and include/exclude-labels filtering so release notes stay clean.

## 📝 Changes

- Autolabeler rules updated to emit `type: feat`, `type: fix`, `type: docs`, `type: refactor`, `type: test`, `type: chore`, `type: ci`, `type: revert` (previously bare `feat`/`fix`/`docs`/`chore`/`refactor`/`ci`/`deps`)
- Added `!` (breaking change) detection in conventional commit titles, autolabeled as `breaking-change`
- `version-resolver` updated: major → `breaking-change`, minor → `type: feat`, patch → the remaining `type: *` labels
- Categories reorganized with a new "⚠️ Breaking Changes" section, plus dedicated "✅ Tests" and "🔄 Refactoring" sections
- Added `include-labels` / `exclude-labels` (`skip-changelog`, `internal`) to control which PRs appear in release notes
- Added `commitish: main`

## 🧪 Validation

- Manual review of the YAML for syntax/structure correctness
- Not run against release-drafter directly (no local runner); will validate on the next generated draft release

## 💬 Notes for Reviewers

This changes the label vocabulary release-drafter expects. Existing/dependabot PRs using old bare labels (`deps`, `feat`, etc.) won't be picked up under the new scheme unless relabeled — worth confirming label conventions across the repo match `type: *` going forward.