### PR TITLE
feat: migrate to Compono.Logging and CompositionBuilder.Share<T>(), bump to 0.9.0-preview.90

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -85,15 +85,17 @@
   </ItemGroup>
   <!-- Compono ecosystem migration (PLAN-0051, LayeredCraft/compono) - the
        HTTP-testing-touched projects (AlexaVoxCraft.Smapi.Tests, AlexaVoxCraft.InSkillPurchasing.Tests)
-       and their shared HTTP TestKit. 0.8.0 is the real published NuGet.org version
-       (LayeredCraft/compono PRs #109/#111, merged) - lockstep across all Compono packages,
-       replacing the "1.0.0" local-pack placeholder used during dogfooding/validation. -->
+       and their shared HTTP TestKit, plus Compono.Logging (PLAN-0055, LayeredCraft/compono#116,
+       merged) and CompositionBuilder.Share<T>() (PLAN-0056, LayeredCraft/compono#117, merged).
+       0.9.0-preview.90 is the real published NuGet.org version - lockstep across all Compono
+       packages, replacing the "1.0.0" local-pack placeholder used during dogfooding/validation. -->
   <ItemGroup Label="Compono">
-    <PackageVersion Include="Compono" Version="0.8.0" />
-    <PackageVersion Include="Compono.XunitV3" Version="0.8.0" />
-    <PackageVersion Include="Compono.Http" Version="0.8.0" />
-    <PackageVersion Include="Compono.TestDoubles" Version="0.8.0" />
-    <PackageVersion Include="Compono.Bogus" Version="0.8.0" />
+    <PackageVersion Include="Compono" Version="0.9.0-preview.90" />
+    <PackageVersion Include="Compono.XunitV3" Version="0.9.0-preview.90" />
+    <PackageVersion Include="Compono.Http" Version="0.9.0-preview.90" />
+    <PackageVersion Include="Compono.TestDoubles" Version="0.9.0-preview.90" />
+    <PackageVersion Include="Compono.Bogus" Version="0.9.0-preview.90" />
+    <PackageVersion Include="Compono.Logging" Version="0.9.0-preview.90" />
   </ItemGroup>
   <ItemGroup Label="Reference Assemblies">
     <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.11" />

--- a/test/AlexaVoxCraft.MediatR.Tests/AlexaVoxCraft.MediatR.Tests.csproj
+++ b/test/AlexaVoxCraft.MediatR.Tests/AlexaVoxCraft.MediatR.Tests.csproj
@@ -26,6 +26,7 @@
         <PackageReference Include="Compono" />
         <PackageReference Include="Compono.XunitV3" />
         <PackageReference Include="Compono.TestDoubles" />
+        <PackageReference Include="Compono.Logging" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/AlexaVoxCraft.MediatR.Tests/Pipeline/PerformanceLoggingBehaviorTests.cs
+++ b/test/AlexaVoxCraft.MediatR.Tests/Pipeline/PerformanceLoggingBehaviorTests.cs
@@ -1,10 +1,10 @@
 using Compono;
+using Compono.Logging;
 using Compono.XunitV3;
 using AlexaVoxCraft.MediatR.Tests.TestKit;
 using AlexaVoxCraft.MediatR.Pipeline;
 using AlexaVoxCraft.Model.Request;
 using AlexaVoxCraft.Model.Response;
-using LayeredCraft.StructuredLogging.Testing;
 using Microsoft.Extensions.Logging;
 
 namespace AlexaVoxCraft.MediatR.Tests.Pipeline;
@@ -15,7 +15,7 @@ public class PerformanceLoggingBehaviorTests : TestBase
     [Theory]
     [Compose<MediatRTestProfile>]
     public async Task Handle_WithSuccessfulRequest_LogsDebugMessages(
-        [Shared] ILogger<PerformanceLoggingBehavior> logger,
+        ILogger<PerformanceLoggingBehavior> logger,
         PerformanceLoggingBehavior behavior,
         IHandlerInput handlerInput,
         [Shared] FakeRequestHandlerDelegate next,
@@ -32,17 +32,16 @@ public class PerformanceLoggingBehaviorTests : TestBase
         // Assert
         result.Should().Be(expectedResponse);
 
-        // Verify logging using structured logging testing extensions
-        var testLogger = (TestLogger<PerformanceLoggingBehavior>)logger;
-        testLogger.AssertLogCount(LogLevel.Debug, 2);
-        testLogger.HasLogEntry(LogLevel.Debug, "Processing Alexa skill request").Should().BeTrue();
-        testLogger.HasLogEntry(LogLevel.Debug, "Successfully processed Alexa skill request").Should().BeTrue();
+        // Verify logging using Compono.Logging
+        logger.GetCapturedEntries().Count(e => e.LogLevel == LogLevel.Debug).Should().Be(2);
+        logger.Verify().AtLevel(LogLevel.Debug).WithMessageContaining("Processing Alexa skill request").Once();
+        logger.Verify().AtLevel(LogLevel.Debug).WithMessageContaining("Successfully processed Alexa skill request").Once();
     }
 
     [Theory]
     [Compose<MediatRTestProfile>]
     public async Task Handle_WithException_LogsErrorAndRethrows(
-        [Shared] ILogger<PerformanceLoggingBehavior> logger,
+        ILogger<PerformanceLoggingBehavior> logger,
         PerformanceLoggingBehavior behavior,
         IHandlerInput handlerInput,
         [Shared] FakeRequestHandlerDelegate next,
@@ -59,17 +58,19 @@ public class PerformanceLoggingBehaviorTests : TestBase
 
         exception.Should().Be(expectedException);
 
-        // Verify error logging using structured logging testing extensions
-        var testLogger = (TestLogger<PerformanceLoggingBehavior>)logger;
-        testLogger.AssertLogCount(LogLevel.Error, 1);
-        testLogger.HasLogEntry(LogLevel.Error, "Failed to process Alexa skill request").Should().BeTrue();
-        testLogger.HasLogEntryWithException<InvalidOperationException>(LogLevel.Error).Should().BeTrue();
+        // Verify error logging using Compono.Logging
+        logger.GetCapturedEntries().Count(e => e.LogLevel == LogLevel.Error).Should().Be(1);
+        logger.Verify()
+            .AtLevel(LogLevel.Error)
+            .WithMessageContaining("Failed to process Alexa skill request")
+            .WithException<InvalidOperationException>()
+            .Once();
     }
 
     [Theory]
     [Compose<MediatRTestProfile>]
     public async Task Handle_WithIntentRequest_LogsIntentName(
-        [Shared] ILogger<PerformanceLoggingBehavior> logger,
+        ILogger<PerformanceLoggingBehavior> logger,
         PerformanceLoggingBehavior behavior,
         [Shared] IHandlerInput handlerInput,
         [Shared] FakeRequestHandlerDelegate next,
@@ -84,16 +85,14 @@ public class PerformanceLoggingBehaviorTests : TestBase
         await behavior.Handle(handlerInput, CancellationToken, next);
 
         // Assert
-        var testLogger = (TestLogger<PerformanceLoggingBehavior>)logger;
-        testLogger.HasLogEntry(LogLevel.Debug, "Processing Alexa skill request").Should().BeTrue();
-        var debugEntries = testLogger.GetLogEntriesContaining("TestIntent");
-        debugEntries.Should().NotBeEmpty();
+        logger.Verify().AtLevel(LogLevel.Debug).WithMessageContaining("Processing Alexa skill request").Once();
+        logger.GetCapturedEntries().Where(e => e.Message.Contains("TestIntent")).Should().NotBeEmpty();
     }
 
     [Theory]
     [Compose<MediatRTestProfile>]
     public async Task Handle_WithNonIntentRequest_LogsWithoutIntentName(
-        [Shared] ILogger<PerformanceLoggingBehavior> logger,
+        ILogger<PerformanceLoggingBehavior> logger,
         PerformanceLoggingBehavior behavior,
         [Shared] IHandlerInput handlerInput,
         [Shared] FakeRequestHandlerDelegate next,
@@ -108,15 +107,14 @@ public class PerformanceLoggingBehaviorTests : TestBase
         await behavior.Handle(handlerInput, CancellationToken, next);
 
         // Assert
-        var testLogger = (TestLogger<PerformanceLoggingBehavior>)logger;
-        testLogger.HasLogEntry(LogLevel.Debug, "Processing Alexa skill request").Should().BeTrue();
-        testLogger.AssertLogCount(LogLevel.Debug, 2);
+        logger.Verify().AtLevel(LogLevel.Debug).WithMessageContaining("Processing Alexa skill request").Once();
+        logger.GetCapturedEntries().Count(e => e.LogLevel == LogLevel.Debug).Should().Be(2);
     }
 
     [Theory]
     [Compose<MediatRTestProfile>]
     public async Task Handle_CallsNextDelegate_ExactlyOnce(
-        [Shared] TestLogger<PerformanceLoggingBehavior> logger,
+        ILogger<PerformanceLoggingBehavior> logger,
         PerformanceLoggingBehavior behavior,
         IHandlerInput handlerInput,
         [Shared] FakeRequestHandlerDelegate next,
@@ -137,7 +135,7 @@ public class PerformanceLoggingBehaviorTests : TestBase
     [Theory]
     [Compose<MediatRTestProfile>]
     public async Task Handle_CreatesProperScope_WithRequestContext(
-        [Shared] ILogger<PerformanceLoggingBehavior> logger,
+        ILogger<PerformanceLoggingBehavior> logger,
         PerformanceLoggingBehavior behavior,
         IHandlerInput handlerInput,
         [Shared] FakeRequestHandlerDelegate next,
@@ -152,10 +150,9 @@ public class PerformanceLoggingBehaviorTests : TestBase
         await behavior.Handle(handlerInput, CancellationToken, next);
 
         // Assert - scope creation and proper logging should occur
-        var testLogger = (TestLogger<PerformanceLoggingBehavior>)logger;
-        testLogger.AssertLogCount(LogLevel.Debug, 2);
-        testLogger.HasLogEntry(LogLevel.Debug, "Processing Alexa skill request").Should().BeTrue();
-        testLogger.HasLogEntry(LogLevel.Debug, "Successfully processed Alexa skill request").Should().BeTrue();
+        logger.GetCapturedEntries().Count(e => e.LogLevel == LogLevel.Debug).Should().Be(2);
+        logger.Verify().AtLevel(LogLevel.Debug).WithMessageContaining("Processing Alexa skill request").Once();
+        logger.Verify().AtLevel(LogLevel.Debug).WithMessageContaining("Successfully processed Alexa skill request").Once();
     }
 
     [Theory]
@@ -171,7 +168,7 @@ public class PerformanceLoggingBehaviorTests : TestBase
     [Theory]
     [Compose<MediatRTestProfile>]
     public async Task Handle_LogsRequestTypeAndApplicationId(
-        [Shared] ILogger<PerformanceLoggingBehavior> logger,
+        ILogger<PerformanceLoggingBehavior> logger,
         PerformanceLoggingBehavior behavior,
         [Shared] IHandlerInput handlerInput,
         [Shared] FakeRequestHandlerDelegate next,
@@ -186,9 +183,7 @@ public class PerformanceLoggingBehaviorTests : TestBase
         await behavior.Handle(handlerInput, CancellationToken, next);
 
         // Assert
-        var testLogger = (TestLogger<PerformanceLoggingBehavior>)logger;
-        var debugEntries = testLogger.GetLogEntriesContaining("LaunchRequest");
-        debugEntries.Should().NotBeEmpty();
-        testLogger.AssertLogCount(LogLevel.Debug, 2);
+        logger.GetCapturedEntries().Where(e => e.Message.Contains("LaunchRequest")).Should().NotBeEmpty();
+        logger.GetCapturedEntries().Count(e => e.LogLevel == LogLevel.Debug).Should().Be(2);
     }
 }

--- a/test/AlexaVoxCraft.MediatR.Tests/TestKit/MediatRTestProfile.cs
+++ b/test/AlexaVoxCraft.MediatR.Tests/TestKit/MediatRTestProfile.cs
@@ -7,7 +7,7 @@ using AlexaVoxCraft.Model.Request;
 using AlexaVoxCraft.Model.Response;
 using AlexaVoxCraft.Model.Request.Type;
 using Compono;
-using LayeredCraft.StructuredLogging.Testing;
+using Compono.Logging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -27,15 +27,20 @@ public sealed class MediatRTestProfile : ICompositionProfile
 {
     public void Configure(CompositionBuilder builder) =>
         builder
+            // UseLogging() registered before UseGeneratedTestDoubles() (stage-6 first-registered-
+            // wins, ADR-0055) - PerformanceLoggingBehavior's ILogger<T> asserts observable log
+            // output, so it needs Compono.Logging's CapturingLogger<T>, not a generated double of
+            // the ILogger<T> interface shape. Every other ILogger<T> constructor dependency in
+            // this project is never itself asserted against, so this ordering doesn't change their
+            // behavior (they'd resolve to a CapturingLogger<T> too now, which is fine - unused).
+            .UseLogging(options => options.MinimumLevel = LogLevel.Debug)
+            // docs/adr/0056-composition-builder-share-graph-wide-sharing.md: every request for
+            // ILogger<PerformanceLoggingBehavior> anywhere in the graph now participates
+            // automatically - PerformanceLoggingBehaviorTests.cs's own `logger` theory parameters
+            // no longer need [Shared] to observe the exact instance PerformanceLoggingBehavior
+            // itself logs through.
+            .Share<ILogger<PerformanceLoggingBehavior>>()
             .UseGeneratedTestDoubles()
-            // The only ILogger<T> this project's tests actually assert observable behavior
-            // against (AssertLogCount/HasLogEntry, from LayeredCraft.StructuredLogging.Testing) -
-            // a real TestLogger<T>, not a UseGeneratedTestDoubles() fake of the ILogger<T>
-            // interface shape (confirmed: every other ILogger<T> constructor dependency in this
-            // project is never itself asserted against, so the generated double suffices for
-            // those - no open-generic Register<ILogger<T>> rule needed).
-            .Register<ILogger<PerformanceLoggingBehavior>>(() =>
-                new TestLogger<PerformanceLoggingBehavior> { MinimumLogLevel = LogLevel.Debug })
             // Every real theory in this project composes SkillResponse directly somewhere in the
             // project (a compile-time discovery root), so this nested context.Resolve<SkillResponse>()
             // is not RESEARCH-0010 Finding B's shape - included here only because an unconfigured
@@ -67,7 +72,7 @@ public sealed class MediatRTestProfile : ICompositionProfile
             // generated test-double closure ever reaches it, and the nested
             // context.Resolve<ILogger<SkillMediator>>() below genuinely threw CompositionException
             // ("no ... test-double provider ... could satisfy"). SkillMediator's own logger is never
-            // asserted against by any test here (unlike PerformanceLoggingBehavior's TestLogger<T>
+            // asserted against by any test here (unlike PerformanceLoggingBehavior's CapturingLogger<T>
             // above), so a plain NullLogger<T> is the right fallback, not a generated double.
             .Register<ILogger<SkillMediator>>(() => Microsoft.Extensions.Logging.Abstractions.NullLogger<SkillMediator>.Instance)
             .Register<IServiceProvider>(context =>


### PR DESCRIPTION
## Summary

- Migrates `PerformanceLoggingBehaviorTests.cs` off `LayeredCraft.StructuredLogging.Testing`'s `TestLogger<T>` onto `Compono.Logging`'s `CapturingLogger<T>`/`Verify()` fluent API (PLAN-0055, [LayeredCraft/compono#116](https://github.com/LayeredCraft/compono/pull/116)).
- Adds `.Share<ILogger<PerformanceLoggingBehavior>>()` to `MediatRTestProfile` and removes `[Shared]` from all eight `ILogger<PerformanceLoggingBehavior> logger` theory parameters — an ordinary, undecorated parameter now observes the same instance `PerformanceLoggingBehavior` itself logs through, the motivating case for `CompositionBuilder.Share<T>()` (ADR-0056/PLAN-0056, [LayeredCraft/compono#117](https://github.com/LayeredCraft/compono/pull/117)).
- Bumps `Compono`/`Compono.XunitV3`/`Compono.Http`/`Compono.TestDoubles`/`Compono.Bogus`/`Compono.Logging` to the real, published `0.9.0-preview.90`.

## Test plan

- [x] `dotnet restore` against the real published `0.9.0-preview.90` (not a local dogfood feed)
- [x] `dotnet build -c Release` — 0 errors
- [x] `dotnet test -c Release` — 2816 total, 0 failed, 2784 succeeded, 32 skipped (pre-existing, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)